### PR TITLE
Provision PostgreSQL tests via Testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,36 +7,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    env:
-      DATABASE_URL: jdbc:postgresql://localhost:5432/basic
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      # Start PostgreSQL ourselves instead of via a `services:` block so a transient Docker Hub pull
-      # timeout retries rather than failing the whole job (a `services:` image pull has no retry).
-      # The configuration otherwise mirrors the previous service container.
-      - name: Start PostgreSQL
-        run: |
-          for attempt in 1 2 3 4 5; do
-            docker pull postgres:latest && break
-            echo "::warning::postgres image pull failed (attempt $attempt/5); retrying in 10s"
-            sleep 10
-          done
-          docker run -d --name postgres \
-            -e POSTGRES_DB=basic \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=password \
-            -p 5432:5432 \
-            --health-cmd="pg_isready -U postgres" \
-            --health-interval=10s --health-timeout=5s --health-retries=5 \
-            postgres:latest
-          echo "Waiting for PostgreSQL to accept connections..."
-          for i in $(seq 1 30); do
-            docker exec postgres pg_isready -U postgres >/dev/null 2>&1 && { echo "PostgreSQL is ready"; break; }
-            sleep 2
-          done
+      # PostgreSQL is provisioned by the tests themselves via Testcontainers (with a local-:5432
+      # fast path), and they cancel gracefully if Docker is unavailable — so CI no longer needs to
+      # stand up a Postgres service or container here.
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -204,6 +204,7 @@ lazy val postgresql = project.in(file("postgresql"))
 		Test / fork := true,
 		libraryDependencies ++= Seq(
 			"org.postgresql" % "postgresql" % postgresqlVersion,
+			"org.testcontainers" % "testcontainers" % testcontainersVersion % Test,
 			"org.scalatest" %% "scalatest" % scalaTestVersion % Test
 		)
 	)

--- a/postgresql/src/test/scala/spec/PostgreSQLAvailability.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLAvailability.scala
@@ -1,0 +1,14 @@
+package spec
+
+import org.scalatest.{AsyncTestSuite, FutureOutcome}
+
+/**
+ * Cancels (rather than fails) every test in a PostgreSQL-backed spec when no PostgreSQL is reachable
+ * — neither a local server on :5432 nor Docker/Testcontainers. Mirrors [[MongoDBAvailability]].
+ */
+trait PostgreSQLAvailability extends AsyncTestSuite {
+  abstract override def withFixture(test: NoArgAsyncTest): FutureOutcome =
+    if PostgreSQLTestSupport.jdbcUrl.isEmpty then
+      FutureOutcome.canceled("PostgreSQL unavailable — no local server on :5432 and Docker/Testcontainers not available. Skipping.")
+    else super.withFixture(test)
+}

--- a/postgresql/src/test/scala/spec/PostgreSQLColumnCaseSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLColumnCaseSpec.scala
@@ -4,9 +4,7 @@ import fabric.rw.*
 import lightdb.LightDB
 import lightdb.doc.{JsonConversion, RecordDocument, RecordDocumentModel}
 import lightdb.id.Id
-import lightdb.postgresql.PostgreSQLStoreManager
 import lightdb.store.{Collection, CollectionManager}
-import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
 import lightdb.time.Timestamp
 import lightdb.upgrade.DatabaseUpgrade
 import org.scalatest.BeforeAndAfterAll
@@ -43,19 +41,13 @@ import java.sql.{Connection, DriverManager}
  * actually be gone.
  */
 @EmbeddedTest
-class PostgreSQLColumnCaseSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with BeforeAndAfterAll {
+class PostgreSQLColumnCaseSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with BeforeAndAfterAll with PostgreSQLAvailability {
   private val schema = "PostgreSQLColumnCaseSpec"
   private val table  = "schema_evolution_record"
 
-  private val jdbcUrl  = "jdbc:postgresql://localhost:5432/basic"
-  private val jdbcUser = "postgres"
-  private val jdbcPass = "password"
-
-  private def sqlConfig: SQLConfig = SQLConfig(
-    jdbcUrl  = jdbcUrl,
-    username = Some(jdbcUser),
-    password = Some(jdbcPass)
-  )
+  private def jdbcUrl: String = PostgreSQLTestSupport.jdbcUrl.get
+  private def jdbcUser: String = PostgreSQLTestSupport.username
+  private def jdbcPass: String = PostgreSQLTestSupport.password
 
   private def withJdbc[T](f: Connection => T): T = {
     val c = DriverManager.getConnection(jdbcUrl, jdbcUser, jdbcPass)
@@ -65,7 +57,8 @@ class PostgreSQLColumnCaseSpec extends AsyncWordSpec with AsyncTaskSpec with Mat
   /** Drop the test schema so every run starts from a clean slate. */
   override def beforeAll(): Unit = {
     super.beforeAll()
-    withJdbc { c =>
+    // `beforeAll` runs before per-test cancellation, so skip when PostgreSQL is unavailable.
+    if PostgreSQLTestSupport.jdbcUrl.isDefined then withJdbc { c =>
       val st = c.createStatement()
       try st.executeUpdate(s"""DROP SCHEMA IF EXISTS "$schema" CASCADE""")
       finally st.close()
@@ -138,7 +131,7 @@ class PostgreSQLColumnCaseSpec extends AsyncWordSpec with AsyncTaskSpec with Mat
   /** Database "version A" — its model still has `legacyCamelField`. */
   object DBBefore extends LightDB {
     override type SM = CollectionManager
-    override val storeManager: CollectionManager = PostgreSQLStoreManager(HikariConnectionManager(sqlConfig))
+    override val storeManager: CollectionManager = PostgreSQLTestSupport.storeManager
     override def name: String = schema
     lazy val directory: Option[Path] = Some(Path.of(s"db/$schema"))
     val records: Collection[RecordWithLegacyColumn, RecordWithLegacyColumn.type] =
@@ -150,7 +143,7 @@ class PostgreSQLColumnCaseSpec extends AsyncWordSpec with AsyncTaskSpec with Mat
     * Initializing this is the schema-evolution step that crashes. */
   object DBAfter extends LightDB {
     override type SM = CollectionManager
-    override val storeManager: CollectionManager = PostgreSQLStoreManager(HikariConnectionManager(sqlConfig))
+    override val storeManager: CollectionManager = PostgreSQLTestSupport.storeManager
     override def name: String = schema
     lazy val directory: Option[Path] = Some(Path.of(s"db/$schema"))
     val records: Collection[RecordWithoutLegacyColumn, RecordWithoutLegacyColumn.type] =

--- a/postgresql/src/test/scala/spec/PostgreSQLFacetSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLFacetSpec.scala
@@ -1,15 +1,8 @@
 package spec
 
 import lightdb.postgresql.PostgreSQLStoreManager
-import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
 
 @EmbeddedTest
-class PostgreSQLFacetSpec extends AbstractFacetSpec {
-  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLStoreManager(HikariConnectionManager(SQLConfig(
-    jdbcUrl = s"jdbc:postgresql://localhost:5432/basic",
-    username = Some("postgres"),
-    password = Some("password")
-  )))
+class PostgreSQLFacetSpec extends AbstractFacetSpec with PostgreSQLAvailability {
+  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLTestSupport.storeManager
 }
-
-

--- a/postgresql/src/test/scala/spec/PostgreSQLNestedSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLNestedSpec.scala
@@ -1,14 +1,8 @@
 package spec
 
-import lightdb.postgresql.PostgreSQLStoreManager
-import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
 import lightdb.store.CollectionManager
 
 @EmbeddedTest
-class PostgreSQLNestedSpec extends AbstractNestedSpec {
-  override lazy val storeManager: CollectionManager = PostgreSQLStoreManager(HikariConnectionManager(SQLConfig(
-    jdbcUrl = s"jdbc:postgresql://localhost:5432/basic",
-    username = Some("postgres"),
-    password = Some("password")
-  )))
+class PostgreSQLNestedSpec extends AbstractNestedSpec with PostgreSQLAvailability {
+  override lazy val storeManager: CollectionManager = PostgreSQLTestSupport.storeManager
 }

--- a/postgresql/src/test/scala/spec/PostgreSQLPolyRootSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLPolyRootSpec.scala
@@ -4,8 +4,6 @@ import fabric.rw.*
 import lightdb.LightDB
 import lightdb.doc.{JsonConversion, RecordDocument, RecordDocumentModel}
 import lightdb.id.Id
-import lightdb.postgresql.PostgreSQLStoreManager
-import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
 import lightdb.store.{Collection, CollectionManager}
 import lightdb.time.Timestamp
 import lightdb.upgrade.DatabaseUpgrade
@@ -28,7 +26,7 @@ import java.nio.file.Path
   * Insert one of each subtype, list them back, assert both round-trip.
   * Pre-fix the `toList` step throws. Post-fix both subtypes survive. */
 @EmbeddedTest
-class PostgreSQLPolyRootSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers { spec =>
+class PostgreSQLPolyRootSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with PostgreSQLAvailability { spec =>
   private lazy val specName: String = "PostgreSQLPolyRootSpec"
 
   specName should {
@@ -67,11 +65,7 @@ class PostgreSQLPolyRootSpec extends AsyncWordSpec with AsyncTaskSpec with Match
     }
   }
 
-  lazy val storeManager: CollectionManager = PostgreSQLStoreManager(HikariConnectionManager(SQLConfig(
-    jdbcUrl = "jdbc:postgresql://localhost:5432/basic",
-    username = Some("postgres"),
-    password = Some("password")
-  )))
+  lazy val storeManager: CollectionManager = PostgreSQLTestSupport.storeManager
 
   object DB extends LightDB {
     override type SM = CollectionManager

--- a/postgresql/src/test/scala/spec/PostgreSQLSQLSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLSQLSpec.scala
@@ -1,13 +1,8 @@
 package spec
 
 import lightdb.postgresql.PostgreSQLStoreManager
-import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
 
 @EmbeddedTest
-class PostgreSQLSQLSpec extends AbstractSQLSpec {
-  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLStoreManager(HikariConnectionManager(SQLConfig(
-    jdbcUrl = s"jdbc:postgresql://localhost:5432/basic",
-    username = Some("postgres"),
-    password = Some("password")
-  )))
+class PostgreSQLSQLSpec extends AbstractSQLSpec with PostgreSQLAvailability {
+  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLTestSupport.storeManager
 }

--- a/postgresql/src/test/scala/spec/PostgreSQLSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLSpec.scala
@@ -1,13 +1,8 @@
 package spec
 
 import lightdb.postgresql.PostgreSQLStoreManager
-import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
 
 @EmbeddedTest
-class PostgreSQLSpec extends AbstractBasicSpec {
-  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLStoreManager(HikariConnectionManager(SQLConfig(
-    jdbcUrl = s"jdbc:postgresql://localhost:5432/basic",
-    username = Some("postgres"),
-    password = Some("password")
-  )))
+class PostgreSQLSpec extends AbstractBasicSpec with PostgreSQLAvailability {
+  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLTestSupport.storeManager
 }

--- a/postgresql/src/test/scala/spec/PostgreSQLSpecialCasesSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLSpecialCasesSpec.scala
@@ -1,13 +1,8 @@
 package spec
 
 import lightdb.postgresql.PostgreSQLStoreManager
-import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
 
 @EmbeddedTest
-class PostgreSQLSpecialCasesSpec extends AbstractSpecialCasesSpec {
-  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLStoreManager(HikariConnectionManager(SQLConfig(
-    jdbcUrl = s"jdbc:postgresql://localhost:5432/basic",
-    username = Some("postgres"),
-    password = Some("password")
-  )))
+class PostgreSQLSpecialCasesSpec extends AbstractSpecialCasesSpec with PostgreSQLAvailability {
+  override lazy val storeManager: PostgreSQLStoreManager = PostgreSQLTestSupport.storeManager
 }

--- a/postgresql/src/test/scala/spec/PostgreSQLTestContainer.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLTestContainer.scala
@@ -1,0 +1,46 @@
+package spec
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import fabric.rw.stringRW
+import profig.Profig
+
+import java.time.Duration
+
+/**
+ * Lazily starts a PostgreSQL container via Testcontainers and tears it down at JVM exit (Ryuk also
+ * removes it if the JVM is hard-killed). Testcontainers 2.x doesn't publish the dedicated
+ * `PostgreSQLContainer` module, so this uses a `GenericContainer` (mirroring the other backends).
+ * Image overridable via the `lightdb.postgresql.testcontainers.image` Profig key.
+ */
+private[spec] object PostgreSQLTestContainer {
+  private val Port = 5432
+
+  private class Container(image: DockerImageName) extends GenericContainer[Container](image)
+
+  private lazy val container: Container = {
+    val image = Profig("lightdb.postgresql.testcontainers.image").opt[String].getOrElse("postgres:latest")
+    val c = new Container(DockerImageName.parse(image))
+    c.withExposedPorts(Port)
+    c.withEnv("POSTGRES_DB", "basic")
+    c.withEnv("POSTGRES_USER", "postgres")
+    c.withEnv("POSTGRES_PASSWORD", "password")
+    // postgres logs this line twice (init, then the real start) — wait for the second.
+    c.waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2).withStartupTimeout(Duration.ofMinutes(2)))
+    c
+  }
+
+  private lazy val started: Unit = {
+    container.start()
+    Runtime.getRuntime.addShutdownHook(new Thread(() => {
+      try container.stop()
+      catch { case _: Throwable => () }
+    }))
+  }
+
+  def jdbcUrl: String = {
+    started
+    s"jdbc:postgresql://${container.getHost}:${container.getMappedPort(Port)}/basic"
+  }
+}

--- a/postgresql/src/test/scala/spec/PostgreSQLTestSupport.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLTestSupport.scala
@@ -1,0 +1,46 @@
+package spec
+
+import lightdb.postgresql.PostgreSQLStoreManager
+import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
+
+import java.net.{InetSocketAddress, Socket}
+
+/**
+ * Resolves a PostgreSQL connection for tests, preferring a locally-running instance and only
+ * spinning up Docker when needed:
+ *
+ *   1. probe localhost:5432 — if reachable, use the local server (fast, nothing to start/stop);
+ *   2. otherwise start an ephemeral Testcontainers PostgreSQL (auto-removed at JVM exit);
+ *   3. if Docker is also unavailable, `None` — specs cancel gracefully (see [[PostgreSQLAvailability]]).
+ */
+object PostgreSQLTestSupport {
+  val username = "postgres"
+  val password = "password"
+
+  lazy val jdbcUrl: Option[String] = localUrl().orElse(containerUrl())
+
+  def sqlConfig: SQLConfig = SQLConfig(jdbcUrl = jdbcUrl.get, username = Some(username), password = Some(password))
+
+  def storeManager: PostgreSQLStoreManager = PostgreSQLStoreManager(HikariConnectionManager(sqlConfig))
+
+  private def localUrl(): Option[String] = {
+    val socket = new Socket()
+    try {
+      socket.connect(new InetSocketAddress("localhost", 5432), 500)
+      Some("jdbc:postgresql://localhost:5432/basic")
+    } catch {
+      case _: Throwable => None
+    } finally {
+      try socket.close()
+      catch { case _: Throwable => () }
+    }
+  }
+
+  private def containerUrl(): Option[String] =
+    try Some(PostgreSQLTestContainer.jdbcUrl)
+    catch {
+      case t: Throwable =>
+        scribe.warn(s"PostgreSQL unavailable: no local instance on :5432 and Testcontainers failed to start (${t.getMessage})")
+        None
+    }
+}


### PR DESCRIPTION
Follow-up to the MongoDB PR's CI hardening. The PostgreSQL specs connected to a hard-coded `localhost:5432`, so CI had to stand up Postgres up front — and a transient Docker Hub pull timeout there failed the whole job before any tests ran.

## Change
PostgreSQL tests now self-provision through a new `PostgreSQLTestSupport`, mirroring the MongoDB/OpenSearch setup:
1. use a local server on `:5432` if reachable (fast path for local dev),
2. otherwise start an ephemeral Testcontainers PostgreSQL (torn down at JVM exit),
3. cancel gracefully via `PostgreSQLAvailability` when neither is available.

So an environmental Docker/registry failure now **skips** the Postgres tests instead of failing the build.

- New: `PostgreSQLTestContainer`, `PostgreSQLTestSupport`, `PostgreSQLAvailability`.
- All 7 specs updated (incl. `ColumnCaseSpec`'s raw-JDBC schema reset, guarded for the unavailable case).
- `build.sbt`: adds the Testcontainers test dependency to the `postgresql` module.
- **CI no longer provisions PostgreSQL** — the manual Start-PostgreSQL step is removed.

## Testing
Full Postgres suite passes via Testcontainers locally: **136 tests, 0 failures** across all 7 specs.