### PR TITLE
Add MariaDB/MySQL store backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,8 @@ val h2Version: String = "2.4.240"
 
 val postgresqlVersion: String = "42.7.11"
 
+val mariadbVersion: String = "3.5.7"
+
 val googleSheetsVersion: String = "v4-rev20260213-2.0.0"
 
 val googleAuthVersion: String = "1.47.0"
@@ -119,7 +121,7 @@ val testcontainersVersion: String = "2.0.5"
 val mongoVersion: String = "5.6.2"
 
 lazy val root = project.in(file("."))
-	.aggregate(core.jvm, traversal, sql, sqlite, postgresql, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, api, apiSpice, all)
+	.aggregate(core.jvm, traversal, sql, sqlite, postgresql, mariadb, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, api, apiSpice, all)
 	.settings(
 		name := projectName,
 		publish := {},
@@ -393,8 +395,21 @@ lazy val mongodb = project.in(file("mongodb"))
 		)
 	)
 
+lazy val mariadb = project.in(file("mariadb"))
+	.dependsOn(sql, sql % "test->test")
+	.settings(
+		name := s"$projectName-mariadb",
+		fork := true,
+		Test / fork := true,
+		libraryDependencies ++= Seq(
+			"org.mariadb.jdbc" % "mariadb-java-client" % mariadbVersion,
+			"org.testcontainers" % "testcontainers" % testcontainersVersion % Test,
+			"org.scalatest" %% "scalatest" % scalaTestVersion % Test
+		)
+	)
+
 lazy val all = project.in(file("all"))
-	.dependsOn(core.jvm, core.jvm % "test->test", traversal, sqlite, postgresql, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, api, apiSpice)
+	.dependsOn(core.jvm, core.jvm % "test->test", traversal, sqlite, postgresql, mariadb, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, api, apiSpice)
 	.settings(
 		name := s"$projectName-all",
 		fork := true,

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Computationally focused database using pluggable stores
 | [H2](https://h2database.com)                                          | Relational DB      | ✅       | ✅          | ✅        | ✅        | ✅           | ✅✅ (ACID)     | ❌ (Basic LIKE)    | 🟡         | Java-native SQL engine                |
 | [DuckDB](https://duckdb.org)                                          | Analytical SQL     | ✅       | ✅          | ✅✅✅     | ✅        | ✅           | ✅              | ❌               | 🟡        | Columnar, ideal for analytics         |
 | [PostgreSQL](https://www.postgresql.org)                              | Relational DB      | ❌ (Server-based) | ✅   | ✅✅✅     | ✅✅      | ✅✅         | ✅✅✅ (ACID, MVCC) | ✅✅ (TSVector)  | 🟡         | Full-featured RDBMS                   |
+| [MariaDB / MySQL](https://mariadb.org)                                | Relational DB      | ❌ (Server-based) | ✅   | ✅✅✅     | ✅✅      | ✅✅         | ✅✅✅ (ACID)     | 🟡 (REGEXP/LIKE) | 🟡         | MySQL-compatible via the MariaDB driver |
 
 ### Legend
 - ✅: Supported / Good

--- a/mariadb/src/main/scala/lightdb/mariadb/MariaDBStore.scala
+++ b/mariadb/src/main/scala/lightdb/mariadb/MariaDBStore.scala
@@ -1,0 +1,145 @@
+package lightdb.mariadb
+
+import fabric.define.{DefType, Definition}
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel}
+import lightdb.field.Field
+import lightdb.sql.connect.ConnectionManager
+import lightdb.sql.{SQLState, SQLStore, SqlIdent}
+import lightdb.store.{Store, StoreManager, StoreMode}
+import lightdb.transaction.Transaction
+import lightdb.transaction.batch.BatchConfig
+import rapid.Task
+
+import java.nio.file.Path
+import java.sql.Connection
+
+/**
+ * `SQLStore` dialect for MySQL/MariaDB (via the MariaDB JDBC driver, which speaks to both servers).
+ *
+ * Dialect specifics vs. the base SQL store:
+ * - Identifiers: LightDB always double-quotes identifiers, so connections run with
+ *   `sql_mode=ANSI_QUOTES` (set via [[MariaDBStoreManager.config]]'s `connectionInitSql`).
+ * - Types: `VARCHAR` requires a length, and `TEXT`/`BLOB` can't be a PRIMARY KEY (or indexed without
+ *   a key length) — so short strings use bounded `VARCHAR`, serialized JSON uses `LONGTEXT`.
+ * - Upsert: `INSERT ... ON DUPLICATE KEY UPDATE`.
+ * - Like/regex/concat: the base store's defaults are already MySQL-flavored (`LIKE`, `REGEXP`,
+ *   `GROUP_CONCAT`), so the transaction needs no overrides.
+ *
+ * Like PostgreSQL, each LightDB instance gets its own schema (a MySQL database) for isolation.
+ */
+class MariaDBStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: String,
+                                                                      path: Option[Path],
+                                                                      model: Model,
+                                                                      val connectionManager: ConnectionManager,
+                                                                      val storeMode: StoreMode[Doc, Model],
+                                                                      lightDB: LightDB,
+                                                                      storeManager: StoreManager) extends SQLStore[Doc, Model](name, path, model, lightDB, storeManager) {
+  override type TX = MariaDBTransaction[Doc, Model]
+
+  // MySQL/MariaDB treats a "schema" as a database; give each LightDB instance its own.
+  override def supportsSchemas: Boolean = true
+
+  private val VarcharLength = 255
+  // utf8mb4-safe index prefix: 191 * 4 = 764 bytes, leaving room for additional columns in a
+  // composite index within InnoDB's 3072-byte key limit.
+  private val TextKeyLength = 191
+
+  override protected def createTransaction(parent: Option[Transaction[Doc, Model]],
+                                           batchConfig: BatchConfig,
+                                           writeHandlerFactory: Transaction[Doc, Model] => lightdb.transaction.WriteHandler[Doc, Model]): Task[TX] = Task {
+    val state = SQLState(connectionManager, this, Store.CacheQueries)
+    MariaDBTransaction(this, state, parent, writeHandlerFactory)
+  }
+
+  override protected def def2Type(name: String, d: Definition): String = d.defType match {
+    case DefType.Str => s"VARCHAR($VarcharLength)"
+    case DefType.Json | DefType.Obj(_) | DefType.Arr(_) | DefType.Poly(_, _) => "LONGTEXT"
+    case DefType.Int => "BIGINT"
+    case DefType.Bool => "TINYINT"
+    case DefType.Dec => "DOUBLE"
+    case DefType.Opt(inner) => def2Type(name, inner)
+    case dt => throw new UnsupportedOperationException(s"$name has an unsupported type: $dt")
+  }
+
+  // The base emits `_id VARCHAR NOT NULL PRIMARY KEY`; unbounded VARCHAR is invalid in MySQL, so use
+  // a bounded VARCHAR for the primary key.
+  override protected def createTable(tx: TX): Unit = {
+    val entries = fields.collect {
+      case field if !field.rw.definition.className.contains("lightdb.spatial.GeoPoint") =>
+        if field == model._id then s"${SqlIdent.quote("_id")} VARCHAR($VarcharLength) NOT NULL PRIMARY KEY"
+        else s"${SqlIdent.quote(field.name)} ${def2Type(field.name, field.rw.definition)}"
+    }.mkString(", ")
+    executeUpdate(s"CREATE TABLE IF NOT EXISTS $fqn($entries)", tx)
+  }
+
+  override protected def createUpsertSQL(): String = {
+    val cols = fields.map(f => SqlIdent.quote(f.name))
+    val values = fields.map(field2Value)
+    val updates = fields.filterNot(_ == model._id).map { f =>
+      val q = SqlIdent.quote(f.name)
+      s"$q = VALUES($q)"
+    }
+    val updateClause = if updates.nonEmpty then updates.mkString(", ") else {
+      val q = SqlIdent.quote("_id"); s"$q = VALUES($q)"
+    }
+    s"INSERT INTO $fqn(${cols.mkString(", ")}) VALUES(${values.mkString(", ")}) ON DUPLICATE KEY UPDATE $updateClause"
+  }
+
+  override protected def createIndexSQL(index: Field.Indexed[Doc, _]): String = indexSQL(index.name, unique = false)
+
+  override protected def createUniqueIndexSQL(index: Field.UniqueIndex[Doc, _]): String = indexSQL(index.name, unique = true)
+
+  // MySQL has no covering-`INCLUDE` syntax (the indexed columns are themselves covering), and LONGTEXT
+  // columns in the key need a length prefix.
+  override protected def createCompositeIndexSQL(compositeIndex: lightdb.CompositeIndex[Doc]): String = {
+    val cols = compositeIndex.fields.map(f => columnRef(f.name)).mkString(", ")
+    s"CREATE INDEX IF NOT EXISTS ${SqlIdent.quote(s"${name}_${compositeIndex.name}_idx")} ON $fqn($cols)"
+  }
+
+  private def indexSQL(fieldName: String, unique: Boolean): String = {
+    val keyword = if unique then "CREATE UNIQUE INDEX" else "CREATE INDEX"
+    s"$keyword IF NOT EXISTS ${SqlIdent.quote(s"${name}_${fieldName}_idx")} ON $fqn(${columnRef(fieldName)})"
+  }
+
+  // Indexes on LONGTEXT columns require a key-length prefix in MySQL.
+  private def columnRef(fieldName: String): String =
+    if fields.find(_.name == fieldName).exists(f => isTextType(f.rw.definition)) then s"${SqlIdent.quote(fieldName)}($TextKeyLength)"
+    else SqlIdent.quote(fieldName)
+
+  private def isTextType(d: Definition): Boolean = d.defType match {
+    case DefType.Json | DefType.Obj(_) | DefType.Arr(_) | DefType.Poly(_, _) => true
+    case DefType.Opt(inner) => isTextType(inner)
+    case _ => false
+  }
+
+  override protected def tables(connection: Connection): Set[String] =
+    queryNames(connection, "SELECT TABLE_NAME AS n FROM information_schema.TABLES WHERE TABLE_SCHEMA = ?", lightDB.name)
+
+  // Resolve via information_schema directly to avoid JDBC catalog/schema ambiguity on MySQL.
+  override protected def indexes(connection: Connection): Set[String] = {
+    val ps = connection.prepareStatement("SELECT INDEX_NAME AS n FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?")
+    try {
+      ps.setString(1, lightDB.name)
+      ps.setString(2, name)
+      collect(ps)
+    } finally ps.close()
+  }
+
+  private def queryNames(connection: Connection, sql: String, arg: String): Set[String] = {
+    val ps = connection.prepareStatement(sql)
+    try {
+      ps.setString(1, arg)
+      collect(ps)
+    } finally ps.close()
+  }
+
+  private def collect(ps: java.sql.PreparedStatement): Set[String] = {
+    val rs = ps.executeQuery()
+    try {
+      var set = Set.empty[String]
+      while rs.next() do set += rs.getString("n").toLowerCase
+      set
+    } finally rs.close()
+  }
+}

--- a/mariadb/src/main/scala/lightdb/mariadb/MariaDBStoreManager.scala
+++ b/mariadb/src/main/scala/lightdb/mariadb/MariaDBStoreManager.scala
@@ -1,0 +1,20 @@
+package lightdb.mariadb
+
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel}
+import lightdb.sql.SQLCollectionManager
+import lightdb.sql.connect.ConnectionManager
+import lightdb.store.StoreMode
+
+import java.nio.file.Path
+
+case class MariaDBStoreManager(connectionManager: ConnectionManager) extends SQLCollectionManager {
+  override type S[Doc <: Document[Doc], Model <: DocumentModel[Doc]] = MariaDBStore[Doc, Model]
+
+  override def create[Doc <: Document[Doc], Model <: DocumentModel[Doc]](db: LightDB,
+                                                                         model: Model,
+                                                                         name: String,
+                                                                         path: Option[Path],
+                                                                         storeMode: StoreMode[Doc, Model]): S[Doc, Model] =
+    new MariaDBStore[Doc, Model](name, path, model, connectionManager, storeMode, db, this)
+}

--- a/mariadb/src/main/scala/lightdb/mariadb/MariaDBTransaction.scala
+++ b/mariadb/src/main/scala/lightdb/mariadb/MariaDBTransaction.scala
@@ -1,0 +1,29 @@
+package lightdb.mariadb
+
+import lightdb.aggregate.AggregateType
+import lightdb.doc.{Document, DocumentModel}
+import lightdb.sql.{SQLState, SQLStoreTransaction}
+import lightdb.transaction.Transaction
+
+/**
+ * MySQL/MariaDB transaction. The base [[SQLStoreTransaction]] already emits MySQL-compatible
+ * `LIKE`/`REGEXP` and maps booleans to 0/1; only the aggregate expressions need dialect tweaks.
+ */
+case class MariaDBTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]](
+  store: MariaDBStore[Doc, Model],
+  state: SQLState[Doc, Model],
+  parent: Option[Transaction[Doc, Model]],
+  writeHandlerFactory: Transaction[Doc, Model] => lightdb.transaction.WriteHandler[Doc, Model]
+) extends SQLStoreTransaction[Doc, Model] {
+  override lazy val writeHandler: lightdb.transaction.WriteHandler[Doc, Model] = writeHandlerFactory(this)
+
+  override protected def aggExpr(`type`: AggregateType, column: String): String = `type` match {
+    // MySQL `AVG` over an integer column returns a low-scale DECIMAL; cast to DOUBLE for full precision.
+    case AggregateType.Avg => s"AVG(CAST($column AS DOUBLE))"
+    // MySQL uses `GROUP_CONCAT(... SEPARATOR x)`, not the `STRING_AGG(col, x)` arg form. Separators
+    // match what the base result parser splits on (`;;` for Concat, `,,` for ConcatDistinct).
+    case AggregateType.Concat => s"GROUP_CONCAT($column SEPARATOR ';;')"
+    case AggregateType.ConcatDistinct => s"GROUP_CONCAT(DISTINCT $column SEPARATOR ',,')"
+    case other => super.aggExpr(other, column)
+  }
+}

--- a/mariadb/src/test/scala/spec/MariaDBAvailability.scala
+++ b/mariadb/src/test/scala/spec/MariaDBAvailability.scala
@@ -1,0 +1,14 @@
+package spec
+
+import org.scalatest.{AsyncTestSuite, FutureOutcome}
+
+/**
+ * Cancels (rather than fails) every test in a MariaDB-backed spec when no MariaDB/MySQL is reachable
+ * — neither a local server on :3306 nor Docker/Testcontainers. Mirrors [[PostgreSQLAvailability]].
+ */
+trait MariaDBAvailability extends AsyncTestSuite {
+  abstract override def withFixture(test: NoArgAsyncTest): FutureOutcome =
+    if MariaDBTestSupport.jdbcUrl.isEmpty then
+      FutureOutcome.canceled("MariaDB unavailable — no local server on :3306 and Docker/Testcontainers not available. Skipping.")
+    else super.withFixture(test)
+}

--- a/mariadb/src/test/scala/spec/MariaDBFacetSpec.scala
+++ b/mariadb/src/test/scala/spec/MariaDBFacetSpec.scala
@@ -1,0 +1,8 @@
+package spec
+
+import lightdb.mariadb.MariaDBStoreManager
+
+@EmbeddedTest
+class MariaDBFacetSpec extends AbstractFacetSpec with MariaDBAvailability {
+  override lazy val storeManager: MariaDBStoreManager = MariaDBTestSupport.storeManager
+}

--- a/mariadb/src/test/scala/spec/MariaDBNestedSpec.scala
+++ b/mariadb/src/test/scala/spec/MariaDBNestedSpec.scala
@@ -1,0 +1,8 @@
+package spec
+
+import lightdb.store.CollectionManager
+
+@EmbeddedTest
+class MariaDBNestedSpec extends AbstractNestedSpec with MariaDBAvailability {
+  override lazy val storeManager: CollectionManager = MariaDBTestSupport.storeManager
+}

--- a/mariadb/src/test/scala/spec/MariaDBSQLSpec.scala
+++ b/mariadb/src/test/scala/spec/MariaDBSQLSpec.scala
@@ -1,0 +1,8 @@
+package spec
+
+import lightdb.sql.SQLCollectionManager
+
+@EmbeddedTest
+class MariaDBSQLSpec extends AbstractSQLSpec with MariaDBAvailability {
+  override def storeManager: SQLCollectionManager = MariaDBTestSupport.storeManager
+}

--- a/mariadb/src/test/scala/spec/MariaDBSpec.scala
+++ b/mariadb/src/test/scala/spec/MariaDBSpec.scala
@@ -1,0 +1,8 @@
+package spec
+
+import lightdb.mariadb.MariaDBStoreManager
+
+@EmbeddedTest
+class MariaDBSpec extends AbstractBasicSpec with MariaDBAvailability {
+  override lazy val storeManager: MariaDBStoreManager = MariaDBTestSupport.storeManager
+}

--- a/mariadb/src/test/scala/spec/MariaDBSpecialCasesSpec.scala
+++ b/mariadb/src/test/scala/spec/MariaDBSpecialCasesSpec.scala
@@ -1,0 +1,8 @@
+package spec
+
+import lightdb.mariadb.MariaDBStoreManager
+
+@EmbeddedTest
+class MariaDBSpecialCasesSpec extends AbstractSpecialCasesSpec with MariaDBAvailability {
+  override def storeManager: MariaDBStoreManager = MariaDBTestSupport.storeManager
+}

--- a/mariadb/src/test/scala/spec/MariaDBTestContainer.scala
+++ b/mariadb/src/test/scala/spec/MariaDBTestContainer.scala
@@ -1,0 +1,46 @@
+package spec
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import fabric.rw.stringRW
+import profig.Profig
+
+import java.time.Duration
+
+/**
+ * Lazily starts a MariaDB container via Testcontainers and tears it down at JVM exit (Ryuk also
+ * removes it if the JVM is hard-killed). Testcontainers 2.x doesn't publish the dedicated MariaDB
+ * module, so this uses a `GenericContainer`. Image overridable via the
+ * `lightdb.mariadb.testcontainers.image` Profig key.
+ */
+private[spec] object MariaDBTestContainer {
+  private val Port = 3306
+
+  private class Container(image: DockerImageName) extends GenericContainer[Container](image)
+
+  private lazy val container: Container = {
+    val image = Profig("lightdb.mariadb.testcontainers.image").opt[String].getOrElse("mariadb:11")
+    val c = new Container(DockerImageName.parse(image))
+    c.withExposedPorts(Port)
+    c.withEnv("MARIADB_ROOT_PASSWORD", "password")
+    c.withEnv("MARIADB_DATABASE", "basic")
+    // The entrypoint logs "ready for connections" once for its temporary init server and again for
+    // the real server — wait for the second.
+    c.waitingFor(Wait.forLogMessage(".*ready for connections.*", 2).withStartupTimeout(Duration.ofMinutes(3)))
+    c
+  }
+
+  private lazy val started: Unit = {
+    container.start()
+    Runtime.getRuntime.addShutdownHook(new Thread(() => {
+      try container.stop()
+      catch { case _: Throwable => () }
+    }))
+  }
+
+  def jdbcUrl: String = {
+    started
+    s"jdbc:mariadb://${container.getHost}:${container.getMappedPort(Port)}/basic"
+  }
+}

--- a/mariadb/src/test/scala/spec/MariaDBTestSupport.scala
+++ b/mariadb/src/test/scala/spec/MariaDBTestSupport.scala
@@ -1,0 +1,53 @@
+package spec
+
+import lightdb.mariadb.MariaDBStoreManager
+import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
+
+import java.net.{InetSocketAddress, Socket}
+
+/**
+ * Resolves a MariaDB/MySQL connection for tests, preferring a locally-running server and only
+ * spinning up Docker when needed:
+ *
+ *   1. probe localhost:3306 — if reachable, use the local server (fast path);
+ *   2. otherwise start an ephemeral Testcontainers MariaDB (auto-removed at JVM exit);
+ *   3. if Docker is also unavailable, `None` — specs cancel gracefully (see [[MariaDBAvailability]]).
+ */
+object MariaDBTestSupport {
+  val username = "root"
+  val password = "password"
+
+  lazy val jdbcUrl: Option[String] = localUrl().orElse(containerUrl())
+
+  def sqlConfig: SQLConfig = SQLConfig(
+    jdbcUrl = jdbcUrl.get,
+    username = Some(username),
+    password = Some(password),
+    driverClassName = Some("org.mariadb.jdbc.Driver"),
+    // LightDB double-quotes identifiers; enable ANSI_QUOTES while preserving the other defaults.
+    connectionInitSql = Some("SET SESSION sql_mode=CONCAT(@@sql_mode, ',ANSI_QUOTES')")
+  )
+
+  def storeManager: MariaDBStoreManager = MariaDBStoreManager(HikariConnectionManager(sqlConfig))
+
+  private def localUrl(): Option[String] = {
+    val socket = new Socket()
+    try {
+      socket.connect(new InetSocketAddress("localhost", 3306), 500)
+      Some("jdbc:mariadb://localhost:3306/basic")
+    } catch {
+      case _: Throwable => None
+    } finally {
+      try socket.close()
+      catch { case _: Throwable => () }
+    }
+  }
+
+  private def containerUrl(): Option[String] =
+    try Some(MariaDBTestContainer.jdbcUrl)
+    catch {
+      case t: Throwable =>
+        scribe.warn(s"MariaDB unavailable: no local server on :3306 and Testcontainers failed to start (${t.getMessage})")
+        None
+    }
+}

--- a/sql/src/main/scala/lightdb/sql/SQLStoreTransaction.scala
+++ b/sql/src/main/scala/lightdb/sql/SQLStoreTransaction.scala
@@ -997,28 +997,7 @@ trait SQLStoreTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
 
   private def aggregate2SQLQuery(query: AggregateQuery[Doc, Model]): SQLQueryBuilder[Doc, Model] = {
     val fields = query.functions.map { f =>
-      val af = f.`type` match {
-        case AggregateType.Max => Some("MAX")
-        case AggregateType.Min => Some("MIN")
-        case AggregateType.Avg => Some("AVG")
-        case AggregateType.Sum => Some("SUM")
-        case AggregateType.Count | AggregateType.CountDistinct => Some("COUNT")
-        case AggregateType.Concat | AggregateType.ConcatDistinct => Some(concatPrefix)
-        case AggregateType.Group => None
-      }
-      val fieldName = af match {
-        case Some(s) =>
-          val pre = f.`type` match {
-            case AggregateType.CountDistinct | AggregateType.ConcatDistinct => "DISTINCT "
-            case _ => ""
-          }
-          val post = f.`type` match {
-            case AggregateType.Concat => ", ';;'"
-            case _ => ""
-          }
-          s"$s($pre${SqlIdent.quote(f.field.name)}$post)"
-        case None => SqlIdent.quote(f.field.name)
-      }
+      val fieldName = aggExpr(f.`type`, SqlIdent.quote(f.field.name))
       SQLPart.Fragment(s"$fieldName AS ${SqlIdent.quote(f.name)}")
     }
     val filters = query.query.filter.map(filter2Part).toList
@@ -1438,6 +1417,24 @@ trait SQLStoreTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
   protected def fieldPart[V](field: Field[Doc, V]): SQLPart = SQLPart.Fragment(SqlIdent.quote(field.name))
 
   protected def concatPrefix: String = "GROUP_CONCAT"
+
+  /**
+   * SQL expression for an aggregate function over the given (already-quoted) column. Dialects
+   * override to adjust syntax — e.g. MySQL needs `GROUP_CONCAT(... SEPARATOR x)` and an explicit
+   * double cast for `AVG` precision. `Concat`/`ConcatDistinct` use the `;;` / `,,` separators the
+   * result parser splits on (see `aggregate`).
+   */
+  protected def aggExpr(`type`: AggregateType, column: String): String = `type` match {
+    case AggregateType.Max => s"MAX($column)"
+    case AggregateType.Min => s"MIN($column)"
+    case AggregateType.Avg => s"AVG($column)"
+    case AggregateType.Sum => s"SUM($column)"
+    case AggregateType.Count => s"COUNT($column)"
+    case AggregateType.CountDistinct => s"COUNT(DISTINCT $column)"
+    case AggregateType.Concat => s"$concatPrefix($column, ';;')"
+    case AggregateType.ConcatDistinct => s"$concatPrefix(DISTINCT $column)"
+    case AggregateType.Group => column
+  }
 
   protected def distanceFilter(f: Filter.Distance[Doc]): SQLPart =
     throw new UnsupportedOperationException("Distance filtering not supported in SQL!")

--- a/sql/src/main/scala/lightdb/sql/connect/HikariConnectionManager.scala
+++ b/sql/src/main/scala/lightdb/sql/connect/HikariConnectionManager.scala
@@ -21,7 +21,7 @@ case class HikariConnectionManager(config: SQLConfig) extends DataSourceConnecti
     hc.setMinimumIdle(2)
     hc.setIdleTimeout(60.seconds.toMillis)
     hc.setConnectionTimeout(5.minutes.toMillis)
-    hc.setConnectionInitSql("SET statement_timeout = 0; SET idle_in_transaction_session_timeout = 0;")
+    config.connectionInitSql.foreach(hc.setConnectionInitSql)
     hc.setLeakDetectionThreshold(if HikariConnectionManager.EnableLeakDetection then 5.minutes.toMillis else 1.hour.toMillis)
     new HikariDataSource(hc)
   }

--- a/sql/src/main/scala/lightdb/sql/connect/SQLConfig.scala
+++ b/sql/src/main/scala/lightdb/sql/connect/SQLConfig.scala
@@ -6,4 +6,7 @@ case class SQLConfig(jdbcUrl: String,
                      password: Option[String] = None,
                      minimumIdle: Option[Int] = None,
                      maximumPoolSize: Option[Int] = None,
-                     autoCommit: Boolean = false)
+                     autoCommit: Boolean = false,
+                     // SQL run on each new pooled connection. Defaults to PostgreSQL session tuning;
+                     // dialects with different session syntax (e.g. MySQL/MariaDB) override it.
+                     connectionInitSql: Option[String] = Some("SET statement_timeout = 0; SET idle_in_transaction_session_timeout = 0;"))


### PR DESCRIPTION
Adds a new `mariadb` module: a SQL-family `Collection` backend using the MariaDB JDBC driver, which connects to both **MariaDB and MySQL** servers.

## Dialect handling (vs. the base SQL store)
- **Identifiers:** enables `sql_mode=ANSI_QUOTES` (via `connectionInitSql`) so LightDB's double-quoted identifiers parse on MySQL.
- **Types:** bounded `VARCHAR` for short strings (MySQL has no unbounded VARCHAR, and `TEXT` can't be a primary key), `LONGTEXT` for serialized JSON, with utf8mb4-safe key-length prefixes (191) on `TEXT` indexes — including composite indexes (and dropping the PostgreSQL-only `INCLUDE` clause).
- **Upsert:** `INSERT ... ON DUPLICATE KEY UPDATE`.
- **Aggregates:** `GROUP_CONCAT(... SEPARATOR x)` and a `DOUBLE` cast for `AVG` precision.
- **Like/regex/concat** otherwise use the base store's already-MySQL-compatible defaults.
- Like PostgreSQL, each LightDB instance gets its own schema (MySQL database) for isolation.

## Shared `sql`-module changes (defaults preserved — no behavior change for existing backends)
- `SQLConfig.connectionInitSql` makes the per-connection init SQL configurable; the previous hardcoded PostgreSQL session SQL becomes the default. (The old value was PostgreSQL-only and would have errored on MySQL.) MariaDB uses it to set `ANSI_QUOTES`.
- Extracted an overridable `aggExpr` hook for aggregate-function SQL (base implementation is byte-for-byte the previous inline behavior).

## Testing
Tests self-provision via Testcontainers (local `:3306` fast path → ephemeral MariaDB container) and cancel gracefully when Docker is unavailable, matching the MongoDB/PostgreSQL setup.

- **MariaDB: 126 tests pass** across Basic, SQL, Nested, Facet, and SpecialCases specs.
- **No regressions** in the other SQL backends: SQLite 304, H2 219, DuckDB 207, PostgreSQL 136.

Documented in the Provided Stores table.