### PR TITLE
ArangoDB: native shortest path + full traversal parity

### DIFF
--- a/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
+++ b/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
@@ -122,6 +122,18 @@ case class ArangoDBTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]
       }
     })
 
+  override def nativeShortestPathEdges(fromKey: String, toKey: String): rapid.Stream[Json] = rapid.Stream.fromIterator(Task {
+    val from = s"${store.vertexNamespace}/$fromKey"
+    val to = s"${store.vertexNamespace}/$toKey"
+    // SHORTEST_PATH yields (vertex, edge) pairs; the start vertex's edge is null — filter it out.
+    val aql = "FOR v, e IN OUTBOUND SHORTEST_PATH @from TO @to @@col FILTER e != null RETURN e"
+    val cursor = store.database.query(aql, classOf[RawJson], Map[String, Any]("@col" -> store.arangoName, "from" -> from, "to" -> to).asJava)
+    new Iterator[Json] {
+      override def hasNext: Boolean = cursor.hasNext
+      override def next(): Json = toJson(cursor.next())
+    }
+  })
+
   // -- Raw AQL ------------------------------------------------------------------------------------
   // Parity with SQL's raw-query support. `@@col` is auto-bound to this store's collection when the
   // query references it; the caller supplies any other bind parameters.

--- a/arangodb/src/test/scala/spec/ArangoDBDeliveryPathSpec.scala
+++ b/arangodb/src/test/scala/spec/ArangoDBDeliveryPathSpec.scala
@@ -1,0 +1,16 @@
+package spec
+
+import com.arangodb.ArangoDB
+import lightdb.arangodb.ArangoDBStoreManager
+import lightdb.store.prefix.PrefixScanningStoreManager
+
+@EmbeddedTest
+class ArangoDBDeliveryPathSpec extends AbstractDeliveryPathSpec with ArangoDBAvailability {
+  private val dbName = getClass.getSimpleName
+  ArangoDBTestSupport.config.foreach { c =>
+    val client = new ArangoDB.Builder().host(c.host, c.port).user(c.user).password(c.password).build()
+    try { val db = client.db(dbName); if (db.exists()) db.drop() } finally client.shutdown()
+  }
+  override def storeManager: PrefixScanningStoreManager =
+    ArangoDBStoreManager(ArangoDBTestSupport.config.get, databaseName = Some(dbName))
+}

--- a/arangodb/src/test/scala/spec/ArangoDBEmployeeInfluenceSpec.scala
+++ b/arangodb/src/test/scala/spec/ArangoDBEmployeeInfluenceSpec.scala
@@ -1,0 +1,16 @@
+package spec
+
+import com.arangodb.ArangoDB
+import lightdb.arangodb.ArangoDBStoreManager
+import lightdb.store.prefix.PrefixScanningStoreManager
+
+@EmbeddedTest
+class ArangoDBEmployeeInfluenceSpec extends AbstractEmployeeInfluenceSpec with ArangoDBAvailability {
+  private val dbName = getClass.getSimpleName
+  ArangoDBTestSupport.config.foreach { c =>
+    val client = new ArangoDB.Builder().host(c.host, c.port).user(c.user).password(c.password).build()
+    try { val db = client.db(dbName); if (db.exists()) db.drop() } finally client.shutdown()
+  }
+  override def storeManager: PrefixScanningStoreManager =
+    ArangoDBStoreManager(ArangoDBTestSupport.config.get, databaseName = Some(dbName))
+}

--- a/arangodb/src/test/scala/spec/ArangoDBGraphSpec.scala
+++ b/arangodb/src/test/scala/spec/ArangoDBGraphSpec.scala
@@ -1,0 +1,87 @@
+package spec
+
+import com.arangodb.ArangoDB
+import fabric.rw.*
+import lightdb.LightDB
+import lightdb.arangodb.{ArangoDBStore, ArangoDBStoreManager}
+import lightdb.doc.{Document, DocumentModel, JsonConversion}
+import lightdb.graph.EdgeDocument
+import lightdb.id.{EdgeId, Id}
+import lightdb.store.prefix.PrefixScanningStoreManager
+import lightdb.traversal.syntax.*
+import lightdb.upgrade.DatabaseUpgrade
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import rapid.AsyncTaskSpec
+
+import java.nio.file.Path
+
+/** Verifies ArangoDB's native AQL graph operations: OUTBOUND reachability and SHORTEST_PATH. */
+@EmbeddedTest
+class ArangoDBGraphSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with ArangoDBAvailability {
+  private val dbName = "ArangoDBGraphSpec"
+
+  ArangoDBTestSupport.config.foreach { c =>
+    val client = new ArangoDB.Builder().host(c.host, c.port).user(c.user).password(c.password).build()
+    try { val db = client.db(dbName); if (db.exists()) db.drop() } finally client.shutdown()
+  }
+
+  "ArangoDB native graph" should {
+    "initialize" in {
+      DB.init.succeed
+    }
+    "insert nodes and links" in {
+      for {
+        _ <- DB.nodes.transaction(_.insert(List("A", "B", "C", "D").map(n => Node(n, Id[Node](n)))))
+        // A->B->C->D and a direct shortcut A->D
+        _ <- DB.links.transaction(_.insert(List(
+          Link(Id[Node]("A"), Id[Node]("B")),
+          Link(Id[Node]("B"), Id[Node]("C")),
+          Link(Id[Node]("C"), Id[Node]("D")),
+          Link(Id[Node]("A"), Id[Node]("D"))
+        )))
+      } yield succeed
+    }
+    "find all reachable nodes natively (OUTBOUND)" in {
+      DB.links.transaction { tx =>
+        tx.traverse.bfs[Link, Node, Node](Id[Node]("A")).targetIds.toList.map { ids =>
+          ids.toSet should be(Set(Id[Node]("A"), Id[Node]("B"), Id[Node]("C"), Id[Node]("D")))
+        }
+      }
+    }
+    "find the shortest path natively (SHORTEST_PATH)" in {
+      DB.links.transaction { tx =>
+        tx.traverse.shortestPaths[Link, Node, Node](Id[Node]("A"), Id[Node]("D")).toList.map { paths =>
+          paths.map(_.length) should be(List(1)) // the direct A->D shortcut, not A->B->C->D
+        }
+      }
+    }
+    "dispose" in {
+      DB.truncate().flatMap(_ => DB.dispose).succeed
+    }
+  }
+
+  case class Node(name: String, _id: Id[Node] = Id()) extends Document[Node]
+  object Node extends DocumentModel[Node] with JsonConversion[Node] {
+    override implicit val rw: RW[Node] = RW.gen
+    val name: I[String] = field.index("name", _.name)
+  }
+
+  case class Link(_from: Id[Node], _to: Id[Node], _id: EdgeId[Link, Node, Node]) extends EdgeDocument[Link, Node, Node]
+  object Link extends DocumentModel[Link] with JsonConversion[Link] {
+    override implicit val rw: RW[Link] = RW.gen
+    val from: I[Id[Node]] = field.index("_from", _._from)
+    val to: I[Id[Node]] = field.index("_to", _._to)
+    def apply(from: Id[Node], to: Id[Node]): Link = Link(from, to, EdgeId(from, to))
+  }
+
+  object DB extends LightDB {
+    override type SM = ArangoDBStoreManager
+    override val storeManager: ArangoDBStoreManager = ArangoDBStoreManager(ArangoDBTestSupport.config.get, databaseName = Some(dbName))
+    override def name: String = dbName
+    override lazy val directory: Option[Path] = None
+    val nodes: ArangoDBStore[Node, Node.type] = store(Node)()
+    val links: ArangoDBStore[Link, Link.type] = store(Link)()
+    override def upgrades: List[DatabaseUpgrade] = Nil
+  }
+}

--- a/core/src/main/scala/lightdb/graph/NativeGraphTraversal.scala
+++ b/core/src/main/scala/lightdb/graph/NativeGraphTraversal.scala
@@ -20,4 +20,10 @@ trait NativeGraphTraversal {
    * @param breadthFirst  BFS when true, DFS when false
    */
   def nativeTraverseEdges(startKeys: List[String], maxDepth: Int, breadthFirst: Boolean): rapid.Stream[Json]
+
+  /**
+   * Edges of a shortest OUTBOUND path from `fromKey` to `toKey`, in order, as LightDB-shaped edge
+   * JSON. Empty when no path exists. (Depth bounding is applied by the caller.)
+   */
+  def nativeShortestPathEdges(fromKey: String, toKey: String): rapid.Stream[Json]
 }

--- a/traversal/src/main/scala/lightdb/traversal/graph/EdgeTraversalBuilder.scala
+++ b/traversal/src/main/scala/lightdb/traversal/graph/EdgeTraversalBuilder.scala
@@ -105,7 +105,22 @@ case class EdgeTraversalBuilder[E <: EdgeDocument[E, F, T], F <: Document[F], T 
    * @param target The ID of the target node
    * @return A stream containing the shortest path to the target node, if any
    */
-  def findShortestPath(target: Id[T]): Stream[TraversalPath[E, F, T]] = implementPathFinding(target, findAll = false)
+  def findShortestPath(target: Id[T]): Stream[TraversalPath[E, F, T]] = tx match {
+    case native: NativeGraphTraversal if !edgeFilterSet => nativeShortestPath(native, target)
+    case _ => implementPathFinding(target, findAll = false)
+  }
+
+  private def nativeShortestPath(native: NativeGraphTraversal, target: Id[T]): Stream[TraversalPath[E, F, T]] = rapid.Stream.force {
+    val rw = tx.store.model.rw.asInstanceOf[fabric.rw.RW[E]]
+    for {
+      starts <- fromIds.toList
+      edges <- starts.headOption match {
+        case Some(start) => native.nativeShortestPathEdges(start.value, target.value).map(_.as[E](rw)).toList
+        case None => Task.pure(Nil)
+      }
+    } yield if edges.isEmpty || edges.length > maxDepth then Stream.empty[TraversalPath[E, F, T]]
+      else Stream.emit(TraversalPath[E, F, T](edges))
+  }
 
   /**
    * Execute a BFS traversal that returns a stream of edges


### PR DESCRIPTION
Finishes the ArangoDB graph integration.

## Native shortest path
- New `NativeGraphTraversal.nativeShortestPathEdges(from, to)` core hook; the traversal module's `EdgeTraversalBuilder.findShortestPath` delegates to it when the backend is native and no edge filter is set (otherwise the generic path-finder is used). Non-native backends are unchanged.
- ArangoDB implements it via AQL `FOR v,e IN OUTBOUND SHORTEST_PATH @from TO @to @@col`. Depth bounding is applied by the caller.

## Full traversal-spec parity with OpenSearch
- Wired the remaining shared traversal specs for ArangoDB: `ArangoDBDeliveryPathSpec` (multi-edge-type `.follow` chaining → native `OUTBOUND` per edge collection) and `ArangoDBEmployeeInfluenceSpec` (step-function reachability).
- Added `ArangoDBGraphSpec` proving native `OUTBOUND` reachability and `SHORTEST_PATH` (it selects the length-1 shortcut over a 3-hop path).

## Status
ArangoDB now has full graph-traversal parity with OpenSearch, with **native AQL** for reachability, multi-hop, and shortest-path — plus the document Collection surface, native nested, aggregation, facets, and raw AQL from the prior PRs.

- ArangoDB module: **206 tests green**.
- Shared `findShortestPath` change is regression-free: **RocksDB 265 green**.

`allPaths`/`findPaths` remain on the generic prefix-scan path (no spec exercises them; native `K_PATHS` is a possible follow-up).