### PR TITLE
ArangoDB: native COLLECT aggregation, K_PATHS, persistent indexes, shared client

### DIFF
--- a/arangodb/src/main/scala/lightdb/arangodb/ArangoDBStore.scala
+++ b/arangodb/src/main/scala/lightdb/arangodb/ArangoDBStore.scala
@@ -2,7 +2,7 @@ package lightdb.arangodb
 
 import com.arangodb.{ArangoCollection, ArangoDB, ArangoDBException, ArangoDatabase}
 import com.arangodb.entity.CollectionType
-import com.arangodb.model.CollectionCreateOptions
+import com.arangodb.model.{CollectionCreateOptions, PersistentIndexOptions}
 import fabric.define.DefType
 import lightdb.LightDB
 import lightdb.doc.{Document, DocumentModel}
@@ -84,7 +84,15 @@ class ArangoDBStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: Str
   // HTTP round-trip per document (see ArangoDBTransaction.applyWriteOps).
   override def defaultBatchConfig: BatchConfig = BatchConfig.Buffered()
 
-  override protected def initialize(): Task[Unit] = super.initialize().next(Task(collection).unit)
+  override protected def initialize(): Task[Unit] = super.initialize().next(Task {
+    collection // force collection (and edge/vertex) creation
+    // Persistent indexes for indexed fields so AQL filters/sorts don't full-scan. `_id` is the
+    // primary index; spatial fields are evaluated in-memory; failures are non-fatal.
+    fields.filter(f => f.indexed && f.name != "_id" && !f.isSpatial).foreach { f =>
+      try collection.ensurePersistentIndex(java.util.List.of(ArangoQuery.escapeKey(f.name)), new PersistentIndexOptions())
+      catch { case t: Throwable => scribe.debug(s"Skipping ArangoDB index on $name.${f.name}: ${t.getMessage}") }
+    }
+  })
 
   override protected def createTransaction(parent: Option[Transaction[Doc, Model]],
                                            batchConfig: BatchConfig,

--- a/arangodb/src/main/scala/lightdb/arangodb/ArangoDBStore.scala
+++ b/arangodb/src/main/scala/lightdb/arangodb/ArangoDBStore.scala
@@ -39,8 +39,10 @@ class ArangoDBStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: Str
   with PrefixScanningStore[Doc, Model] {
   override type TX = ArangoDBTransaction[Doc, Model]
 
-  private lazy val client: ArangoDB =
-    new ArangoDB.Builder().host(config.host, config.port).user(config.user).password(config.password).build()
+  // The ArangoDB client (connection pool) is shared across all stores created by the same manager;
+  // the manager refcounts active stores and shuts it down once the last one disposes.
+  private def manager: ArangoDBStoreManager = storeManager.asInstanceOf[ArangoDBStoreManager]
+  private def client: ArangoDB = manager.client
 
   private[arangodb] lazy val database: ArangoDatabase = {
     val d = client.db(databaseName)
@@ -84,7 +86,7 @@ class ArangoDBStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: Str
   // HTTP round-trip per document (see ArangoDBTransaction.applyWriteOps).
   override def defaultBatchConfig: BatchConfig = BatchConfig.Buffered()
 
-  override protected def initialize(): Task[Unit] = super.initialize().next(Task {
+  override protected def initialize(): Task[Unit] = Task(manager.acquireClient()).next(super.initialize()).next(Task {
     collection // force collection (and edge/vertex) creation
     // Persistent indexes for indexed fields so AQL filters/sorts don't full-scan. `_id` is the
     // primary index; spatial fields are evaluated in-memory; failures are non-fatal.
@@ -99,7 +101,7 @@ class ArangoDBStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: Str
                                            writeHandlerFactory: Transaction[Doc, Model] => lightdb.transaction.WriteHandler[Doc, Model]): Task[TX] =
     Task(ArangoDBTransaction(this, parent, writeHandlerFactory))
 
-  override protected def doDispose(): Task[Unit] = super.doDispose().next(Task(client.shutdown()))
+  override protected def doDispose(): Task[Unit] = super.doDispose().next(Task(manager.releaseClient()))
 }
 
 /**
@@ -110,6 +112,17 @@ class ArangoDBStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: Str
 case class ArangoDBStoreManager(config: ArangoDBConfig,
                                 databaseName: Option[String] = None) extends CollectionManager with PrefixScanningStoreManager {
   override type S[Doc <: Document[Doc], Model <: DocumentModel[Doc]] = ArangoDBStore[Doc, Model]
+
+  // One ArangoDB client (connection pool) shared by all stores from this manager. Refcounted by
+  // active stores; shut down when the last store disposes. (LightDB creates a manager per instance.)
+  private lazy val sharedClient: ArangoDB =
+    new ArangoDB.Builder().host(config.host, config.port).user(config.user).password(config.password).build()
+  private val activeStores = new java.util.concurrent.atomic.AtomicInteger(0)
+
+  private[arangodb] def client: ArangoDB = sharedClient
+  private[arangodb] def acquireClient(): Unit = { activeStores.incrementAndGet(); () }
+  private[arangodb] def releaseClient(): Unit =
+    if (activeStores.decrementAndGet() <= 0) try sharedClient.shutdown() catch { case _: Throwable => () }
 
   override def create[Doc <: Document[Doc], Model <: DocumentModel[Doc]](db: LightDB,
                                                                          model: Model,

--- a/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
+++ b/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
@@ -70,14 +70,16 @@ case class ArangoDBTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]
     JsonFormatter.Compact(Obj(finalMap))
   }
 
-  private def toJson(raw: RawJson): Json = JsonParser(raw.get()) match {
-    // Drop ArangoDB system attributes (`_id`=coll/key, `_rev`, edge `_from`/`_to` handles); restore
-    // escaped names (e.g. `_key`->`_id`, `from_`->`_from`).
+  // Drop ArangoDB system attributes (`_id`=coll/key, `_rev`, edge `_from`/`_to` handles); restore
+  // escaped names (e.g. `_key`->`_id`, `from_`->`_from`).
+  private def mapArangoDoc(json: Json): Json = json match {
     case o: Obj => Obj(o.value.collect {
       case (k, v) if k != "_id" && k != "_rev" && k != "_from" && k != "_to" => ArangoQuery.unescapeKey(k) -> v
     })
     case other => other
   }
+
+  private def toJson(raw: RawJson): Json = mapArangoDoc(JsonParser(raw.get()))
 
   private def fromRaw(raw: RawJson): Doc = toJson(raw).as[Doc](store.model.rw)
 
@@ -131,6 +133,21 @@ case class ArangoDBTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]
     new Iterator[Json] {
       override def hasNext: Boolean = cursor.hasNext
       override def next(): Json = toJson(cursor.next())
+    }
+  })
+
+  override def nativeAllPaths(fromKey: String, toKey: String, maxDepth: Int): rapid.Stream[List[Json]] = rapid.Stream.fromIterator(Task {
+    val from = s"${store.vertexNamespace}/$fromKey"
+    val to = s"${store.vertexNamespace}/$toKey"
+    val max = if maxDepth == Int.MaxValue then 100 else maxDepth // K_PATHS requires a finite bound
+    val aql = s"FOR p IN 1..$max OUTBOUND K_PATHS @from TO @to @@col RETURN p.edges"
+    val cursor = store.database.query(aql, classOf[RawJson], Map[String, Any]("@col" -> store.arangoName, "from" -> from, "to" -> to).asJava)
+    new Iterator[List[Json]] {
+      override def hasNext: Boolean = cursor.hasNext
+      override def next(): List[Json] = JsonParser(cursor.next().get()) match {
+        case Arr(values, _) => values.map(mapArangoDoc).toList
+        case _ => Nil
+      }
     }
   })
 

--- a/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
+++ b/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
@@ -7,7 +7,8 @@ import com.arangodb.util.RawJson
 import fabric.*
 import fabric.io.{JsonFormatter, JsonParser}
 import fabric.rw.*
-import lightdb.aggregate.AggregateQuery
+import lightdb.SortDirection
+import lightdb.aggregate.{AggregateFunction, AggregateQuery, AggregateType}
 import lightdb.doc.{Document, DocumentModel}
 import lightdb.error.DuplicateIdException
 import lightdb.facet.FacetComputation
@@ -389,11 +390,61 @@ case class ArangoDBTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]
     }
   }
 
-  // Aggregation is computed in-memory via the shared `Aggregator`; correct for all
-  // AggregateType/Group/sub-aggregate/Concat cases. Native AQL COLLECT pushdown is a future optimization.
+  // Native AQL COLLECT pushdown for the common shapes (Group + Max/Min/Avg/Sum/Count/CountDistinct,
+  // no sub-aggregates, no HAVING, translatable WHERE). Everything else (sub-aggregates, Concat/
+  // ConcatDistinct, HAVING, residual WHERE) falls back to the correct in-memory `Aggregator`.
   override def aggregate(query: AggregateQuery[Doc, Model]): rapid.Stream[MaterializedAggregate[Doc, Model]] =
-    lightdb.util.Aggregator(query, store.model)
+    if canPushdownAggregate(query) then nativeAggregate(query)
+    else lightdb.util.Aggregator(query, store.model)
 
   override def aggregateCount(query: AggregateQuery[Doc, Model]): Task[Int] =
     aggregate(query).count
+
+  private def canPushdownAggregate(query: AggregateQuery[Doc, Model]): Boolean =
+    query.filter.isEmpty && // HAVING
+      query.functions.nonEmpty &&
+      !query.query.filter.exists(ArangoQuery.filterHasResidual) &&
+      query.functions.forall(f => f.subAggregates.isEmpty && (f.`type` match {
+        case AggregateType.Group | AggregateType.Max | AggregateType.Min | AggregateType.Avg |
+             AggregateType.Sum | AggregateType.Count | AggregateType.CountDistinct => true
+        case _ => false // Concat / ConcatDistinct
+      }))
+
+  private def aqlAggExpr(f: AggregateFunction[_, _, Doc]): String = {
+    val field = s"d.`${ArangoQuery.escapeKey(f.field.name)}`"
+    f.`type` match {
+      case AggregateType.Max => s"MAX($field)"
+      case AggregateType.Min => s"MIN($field)"
+      case AggregateType.Avg => s"AVERAGE($field)"
+      case AggregateType.Sum => s"SUM($field)"
+      case AggregateType.Count => "COUNT_DISTINCT(d.`_key`)" // docs per group (keys are unique)
+      case AggregateType.CountDistinct => s"COUNT_DISTINCT($field)"
+      case other => throw new UnsupportedOperationException(s"Unsupported native aggregate: $other")
+    }
+  }
+
+  private def nativeAggregate(query: AggregateQuery[Doc, Model]): rapid.Stream[MaterializedAggregate[Doc, Model]] = rapid.Stream.fromIterator(Task {
+    val groups = query.functions.filter(_.`type` == AggregateType.Group)
+    val metrics = query.functions.filter(_.`type` != AggregateType.Group)
+    val sb = new StringBuilder("FOR d IN @@col")
+    query.query.filter.foreach(f => sb.append(s" FILTER ${ArangoQuery.translate(f, store.model)}"))
+    sb.append(" COLLECT ")
+    sb.append(groups.map(g => s"`${g.name}` = d.`${ArangoQuery.escapeKey(g.field.name)}`").mkString(", "))
+    if (metrics.nonEmpty) {
+      if (groups.nonEmpty) sb.append(" ")
+      sb.append("AGGREGATE " + metrics.map(m => s"`${m.name}` = ${aqlAggExpr(m)}").mkString(", "))
+    }
+    if (query.sort.nonEmpty) {
+      sb.append(" SORT " + query.sort.map { case (f, dir) => s"`${f.name}` ${if dir == SortDirection.Descending then "DESC" else "ASC"}" }.mkString(", "))
+    }
+    query.limit.foreach(l => sb.append(s" LIMIT $l"))
+    val ret = query.functions.map(f => s"`${f.name}`: `${f.name}`").mkString(", ")
+    sb.append(s" RETURN { $ret }")
+
+    val cursor = store.database.query(sb.toString, classOf[RawJson], Map[String, Any]("@col" -> store.arangoName).asJava)
+    new Iterator[MaterializedAggregate[Doc, Model]] {
+      override def hasNext: Boolean = cursor.hasNext
+      override def next(): MaterializedAggregate[Doc, Model] = MaterializedAggregate[Doc, Model](JsonParser(cursor.next().get()), store.model)
+    }
+  })
 }

--- a/arangodb/src/test/scala/spec/ArangoDBAggregationSpec.scala
+++ b/arangodb/src/test/scala/spec/ArangoDBAggregationSpec.scala
@@ -1,0 +1,71 @@
+package spec
+
+import com.arangodb.ArangoDB
+import fabric.rw.*
+import lightdb.LightDB
+import lightdb.arangodb.{ArangoDBStore, ArangoDBStoreManager}
+import lightdb.doc.{Document, DocumentModel, JsonConversion}
+import lightdb.id.Id
+import lightdb.upgrade.DatabaseUpgrade
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import rapid.AsyncTaskSpec
+
+import java.nio.file.Path
+
+/** Verifies ArangoDB native AQL COLLECT aggregation (grouped sum/count). */
+@EmbeddedTest
+class ArangoDBAggregationSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with ArangoDBAvailability {
+  private val dbName = "ArangoDBAggregationSpec"
+
+  ArangoDBTestSupport.config.foreach { c =>
+    val client = new ArangoDB.Builder().host(c.host, c.port).user(c.user).password(c.password).build()
+    try { val db = client.db(dbName); if (db.exists()) db.drop() } finally client.shutdown()
+  }
+
+  "ArangoDB native aggregation" should {
+    "initialize" in {
+      DB.init.succeed
+    }
+    "insert sales" in {
+      DB.sales.transaction(_.insert(List(
+        Sale("A", 10), Sale("A", 5), Sale("B", 7), Sale("C", 3)
+      ))).succeed
+    }
+    "group by category with sum and count (COLLECT)" in {
+      DB.sales.transaction { tx =>
+        tx.query.aggregate(s => List(s.category.group, s.amount.sum, s.amount.count)).toList.map { rows =>
+          rows.map(r => r(_.category.group) -> (r(_.amount.sum), r(_.amount.count))).toMap should be(
+            Map("A" -> (15, 2), "B" -> (7, 1), "C" -> (3, 1))
+          )
+        }
+      }
+    }
+    "compute global min/max/avg/sum (COLLECT)" in {
+      DB.sales.transaction { tx =>
+        tx.query.aggregate(s => List(s.amount.min, s.amount.max, s.amount.sum)).toList.map { rows =>
+          rows.map(r => (r(_.amount.min), r(_.amount.max), r(_.amount.sum))) should be(List((3, 10, 25)))
+        }
+      }
+    }
+    "dispose" in {
+      DB.truncate().flatMap(_ => DB.dispose).succeed
+    }
+  }
+
+  case class Sale(category: String, amount: Int, _id: Id[Sale] = Sale.id()) extends Document[Sale]
+  object Sale extends DocumentModel[Sale] with JsonConversion[Sale] {
+    override implicit val rw: RW[Sale] = RW.gen
+    val category: I[String] = field.index("category", _.category)
+    val amount: I[Int] = field.index("amount", _.amount)
+  }
+
+  object DB extends LightDB {
+    override type SM = ArangoDBStoreManager
+    override val storeManager: ArangoDBStoreManager = ArangoDBStoreManager(ArangoDBTestSupport.config.get, databaseName = Some(dbName))
+    override def name: String = dbName
+    override lazy val directory: Option[Path] = None
+    val sales: ArangoDBStore[Sale, Sale.type] = store(Sale)()
+    override def upgrades: List[DatabaseUpgrade] = Nil
+  }
+}

--- a/arangodb/src/test/scala/spec/ArangoDBGraphSpec.scala
+++ b/arangodb/src/test/scala/spec/ArangoDBGraphSpec.scala
@@ -56,6 +56,13 @@ class ArangoDBGraphSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers w
         }
       }
     }
+    "find all paths natively (K_PATHS)" in {
+      DB.links.transaction { tx =>
+        tx.traverse.allPaths[Link, Node](Id[Node]("A"), Id[Node]("D"), maxDepth = 5).toList.map { paths =>
+          paths.map(_.length).sorted should be(List(1, 3)) // A->D and A->B->C->D
+        }
+      }
+    }
     "dispose" in {
       DB.truncate().flatMap(_ => DB.dispose).succeed
     }

--- a/core/src/main/scala/lightdb/graph/NativeGraphTraversal.scala
+++ b/core/src/main/scala/lightdb/graph/NativeGraphTraversal.scala
@@ -26,4 +26,10 @@ trait NativeGraphTraversal {
    * JSON. Empty when no path exists. (Depth bounding is applied by the caller.)
    */
   def nativeShortestPathEdges(fromKey: String, toKey: String): rapid.Stream[Json]
+
+  /**
+   * All OUTBOUND paths from `fromKey` to `toKey` within `maxDepth` hops. Each element is one path's
+   * edges in order, as LightDB-shaped edge JSON.
+   */
+  def nativeAllPaths(fromKey: String, toKey: String, maxDepth: Int): rapid.Stream[List[Json]]
 }

--- a/traversal/src/main/scala/lightdb/traversal/graph/EdgeTraversalBuilder.scala
+++ b/traversal/src/main/scala/lightdb/traversal/graph/EdgeTraversalBuilder.scala
@@ -97,7 +97,23 @@ case class EdgeTraversalBuilder[E <: EdgeDocument[E, F, T], F <: Document[F], T 
    * @param target The ID of the target node
    * @return A stream of paths to the target node
    */
-  def findPaths(target: Id[T]): Stream[TraversalPath[E, F, T]] = implementPathFinding(target, findAll = true)
+  def findPaths(target: Id[T]): Stream[TraversalPath[E, F, T]] = tx match {
+    case native: NativeGraphTraversal if !edgeFilterSet => nativeAllPaths(native, target)
+    case _ => implementPathFinding(target, findAll = true)
+  }
+
+  private def nativeAllPaths(native: NativeGraphTraversal, target: Id[T]): Stream[TraversalPath[E, F, T]] = rapid.Stream.force {
+    val rw = tx.store.model.rw.asInstanceOf[fabric.rw.RW[E]]
+    fromIds.toList.map { starts =>
+      starts.headOption match {
+        case Some(start) =>
+          native.nativeAllPaths(start.value, target.value, maxDepth)
+            .map(edgeJsons => TraversalPath[E, F, T](edgeJsons.map(_.as[E](rw))))
+            .filter(_.edges.length <= maxDepth)
+        case None => Stream.empty[TraversalPath[E, F, T]]
+      }
+    }
+  }
 
   /**
    * Find the shortest path to a target node

--- a/traversal/src/main/scala/lightdb/traversal/syntax.scala
+++ b/traversal/src/main/scala/lightdb/traversal/syntax.scala
@@ -5,7 +5,7 @@ import lightdb.graph.EdgeDocument
 import lightdb.id.Id
 import lightdb.transaction.PrefixScanningTransaction
 import lightdb.traversal.graph.{EdgeTraversalBuilder, TraversalPath, TraversalStrategy}
-import rapid.{Pull, Step, Stream, Task}
+import rapid.Stream
 
 /**
  * Syntax / extension methods for enabling the lightweight graph traversal DSL against any
@@ -65,73 +65,15 @@ final class TransactionTraverse[Doc <: Document[Doc], Model <: DocumentModel[Doc
     maxDepth: Int,
     bufferSize: Int = 100,
     edgeFilter: E => Boolean = (_: E) => true
-  )(implicit ev: Doc =:= E): Stream[TraversalPath[E, From, From]] = {
-    allPathsInternal[E, From](
-      from,
-      to,
-      maxDepth,
-      bufferSize,
-      edgeFilter
-    )(edgesFor[E, From, From])
-  }
-
-  private def allPathsInternal[E <: EdgeDocument[E, From, From], From <: Document[From]](
-    from: Id[From],
-    to: Id[From],
-    maxDepth: Int,
-    bufferSize: Int = 100,
-    edgeFilter: E => Boolean = (_: E) => true
-  )(edgesForFunc: Id[From] => Stream[E]): Stream[TraversalPath[E, From, From]] = {
-    import scala.collection.mutable
-
-    val queue = mutable.Queue[(Id[From], List[E])]()
-    val seen = mutable.Set[List[Id[From]]]()
-    queue.enqueue((from, Nil))
-
-    var buffer: List[TraversalPath[E, From, From]] = Nil
-
-    val pullTask: Task[Step[TraversalPath[E, From, From]]] = Task {
-      if buffer.nonEmpty then {
-        val next = buffer.head
-        buffer = buffer.tail
-        Step.Emit(next)
-      } else {
-        var collected = List.empty[TraversalPath[E, From, From]]
-
-        while queue.nonEmpty && collected.size < bufferSize do {
-          val (currentId, path) = queue.dequeue()
-
-          if path.length < maxDepth then {
-            val edges: List[E] = edgesForFunc(currentId).toList.sync()
-            val filteredEdges = edges.filter(edgeFilter)
-            val nextSteps = filteredEdges.filterNot(e => path.exists(_._to == e._to))
-            val newPaths = nextSteps.map(e => (e._to, path :+ e))
-            val (completed, pending) = newPaths.partition(_._1 == to)
-
-            pending.foreach {
-              case (id, newPath) =>
-                val signature = from +: newPath.map(_._to)
-                if !seen.contains(signature) then {
-                  seen += signature
-                  queue.enqueue((id, newPath))
-                }
-            }
-
-            collected ++= completed.map(p => TraversalPath(p._2))
-          }
-        }
-
-        if collected.nonEmpty then {
-          buffer = collected.tail
-          Step.Emit(collected.head)
-        } else {
-          Step.Stop
-        }
-      }
-    }
-    val pull = Pull(pullTask)
-    Stream(Task.pure(pull))
-  }
+  )(implicit ev: Doc =:= E): Stream[TraversalPath[E, From, From]] =
+    _root_.lightdb.traversal
+      .from(from)
+      .withMaxDepth(maxDepth)
+      .follow[E, From](tx.asInstanceOf[PrefixScanningTransaction[E, _]])
+      .findPaths(to)
+      // A path is allowed iff every edge in it passes the filter; applying it here keeps the native
+      // (unfiltered) traversal eligible while preserving edge-filter semantics.
+      .filter(path => path.edges.forall(edgeFilter))
 
   /**
    * Find shortest paths between two nodes.

--- a/traversal/src/main/scala/lightdb/traversal/syntax.scala
+++ b/traversal/src/main/scala/lightdb/traversal/syntax.scala
@@ -4,8 +4,9 @@ import lightdb.doc.{Document, DocumentModel}
 import lightdb.graph.EdgeDocument
 import lightdb.id.Id
 import lightdb.transaction.PrefixScanningTransaction
+import lightdb.graph.NativeGraphTraversal
 import lightdb.traversal.graph.{EdgeTraversalBuilder, TraversalPath, TraversalStrategy}
-import rapid.Stream
+import rapid.{Pull, Step, Stream, Task}
 
 /**
  * Syntax / extension methods for enabling the lightweight graph traversal DSL against any
@@ -65,15 +66,78 @@ final class TransactionTraverse[Doc <: Document[Doc], Model <: DocumentModel[Doc
     maxDepth: Int,
     bufferSize: Int = 100,
     edgeFilter: E => Boolean = (_: E) => true
-  )(implicit ev: Doc =:= E): Stream[TraversalPath[E, From, From]] =
-    _root_.lightdb.traversal
-      .from(from)
-      .withMaxDepth(maxDepth)
-      .follow[E, From](tx.asInstanceOf[PrefixScanningTransaction[E, _]])
-      .findPaths(to)
-      // A path is allowed iff every edge in it passes the filter; applying it here keeps the native
-      // (unfiltered) traversal eligible while preserving edge-filter semantics.
-      .filter(path => path.edges.forall(edgeFilter))
+  )(implicit ev: Doc =:= E): Stream[TraversalPath[E, From, From]] = tx match {
+    // Native backends (e.g. ArangoDB K_PATHS) run the whole path search in the engine. A path is
+    // allowed iff every edge passes the filter, applied here so the native traversal stays eligible.
+    case _: NativeGraphTraversal =>
+      _root_.lightdb.traversal
+        .from(from)
+        .withMaxDepth(maxDepth)
+        .follow[E, From](tx.asInstanceOf[PrefixScanningTransaction[E, _]])
+        .findPaths(to)
+        .filter(path => path.edges.forall(edgeFilter))
+    // Generic backends use the streaming BFS path-finder (lazily emits paths, so `.take(n)` short-circuits).
+    case _ =>
+      allPathsInternal[E, From](from, to, maxDepth, bufferSize, edgeFilter)(edgesFor[E, From, From])
+  }
+
+  private def allPathsInternal[E <: EdgeDocument[E, From, From], From <: Document[From]](
+    from: Id[From],
+    to: Id[From],
+    maxDepth: Int,
+    bufferSize: Int = 100,
+    edgeFilter: E => Boolean = (_: E) => true
+  )(edgesForFunc: Id[From] => Stream[E]): Stream[TraversalPath[E, From, From]] = {
+    import scala.collection.mutable
+
+    val queue = mutable.Queue[(Id[From], List[E])]()
+    val seen = mutable.Set[List[Id[From]]]()
+    queue.enqueue((from, Nil))
+
+    var buffer: List[TraversalPath[E, From, From]] = Nil
+
+    val pullTask: Task[Step[TraversalPath[E, From, From]]] = Task {
+      if buffer.nonEmpty then {
+        val next = buffer.head
+        buffer = buffer.tail
+        Step.Emit(next)
+      } else {
+        var collected = List.empty[TraversalPath[E, From, From]]
+
+        while queue.nonEmpty && collected.size < bufferSize do {
+          val (currentId, path) = queue.dequeue()
+
+          if path.length < maxDepth then {
+            val edges: List[E] = edgesForFunc(currentId).toList.sync()
+            val filteredEdges = edges.filter(edgeFilter)
+            val nextSteps = filteredEdges.filterNot(e => path.exists(_._to == e._to))
+            val newPaths = nextSteps.map(e => (e._to, path :+ e))
+            val (completed, pending) = newPaths.partition(_._1 == to)
+
+            pending.foreach {
+              case (id, newPath) =>
+                val signature = from +: newPath.map(_._to)
+                if !seen.contains(signature) then {
+                  seen += signature
+                  queue.enqueue((id, newPath))
+                }
+            }
+
+            collected ++= completed.map(p => TraversalPath(p._2))
+          }
+        }
+
+        if collected.nonEmpty then {
+          buffer = collected.tail
+          Step.Emit(collected.head)
+        } else {
+          Step.Stop
+        }
+      }
+    }
+    val pull = Pull(pullTask)
+    Stream(Task.pure(pull))
+  }
 
   /**
    * Find shortest paths between two nodes.


### PR DESCRIPTION
A batch of ArangoDB viability improvements (all native AQL).

## Native AQL COLLECT aggregation
`aggregate` pushes down to AQL `COLLECT ... AGGREGATE` for `Group` + `Max`/`Min`/`Avg`(AVERAGE)/`Sum`/`Count`/`CountDistinct` when there are no sub-aggregates, no HAVING, and a translatable `WHERE`; otherwise it falls back to the correct in-memory `Aggregator` (sub-aggregates, `Concat`/`ConcatDistinct`, HAVING, residual filters). `Count` uses `COUNT_DISTINCT(d._key)` (keys are unique).

## Native K_PATHS (all-paths)
`NativeGraphTraversal.nativeAllPaths`; `EdgeTraversalBuilder.findPaths` and `tx.traverse.allPaths` delegate to it for native backends, implemented in ArangoDB via AQL `OUTBOUND K_PATHS`. Generic backends keep the lazy streaming path-finder.

## Persistent indexes on init
Every indexed (non-`_id`, non-spatial) field gets a persistent index, so AQL filters/sorts no longer full-scan the collection — the main real-world performance win.

## Shared client per manager
The ArangoDB client (connection pool) is now owned and refcounted by the manager and shared across its stores (shut down when the last store disposes), instead of one client per store.

## Testing
- `ArangoDBGraphSpec` (OUTBOUND reachability, SHORTEST_PATH, K_PATHS), `ArangoDBAggregationSpec` (grouped + global COLLECT), `ArangoDBRawAqlSpec`, plus the full document + traversal spec suite: **212 ArangoDB tests green**.
- Regression-checked the shared `traversal` change across **all (161), lucene (192), rocksdb (265)** — all green.

Note: an earlier revision of this branch rerouted `syntax.allPaths` through the non-streaming path-finder, which timed out Lucene's all-paths test; that's fixed here (native only for native backends; the lazy `allPathsInternal` restored for the rest).