### PR TITLE
Vector / embedding KNN search (pgvector, Lucene HNSW, Qdrant)

### DIFF
--- a/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
+++ b/arangodb/src/main/scala/lightdb/arangodb/ArangoDBTransaction.scala
@@ -337,6 +337,11 @@ case class ArangoDBTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]
             val field = bf.field.asInstanceOf[Field[Doc, Any]]
             val sorted = acc.sortBy(d => field.getJson(d, state))(jsonOrdering)
             if (bf.direction == lightdb.SortDirection.Descending) sorted.reverse else sorted
+          case _: lightdb.Sort.ByVectorDistance[_] =>
+            throw new UnsupportedOperationException(
+              "Vector search (Sort.ByVectorDistance) is not supported by the ArangoDB backend; " +
+                "use a backend with native vector support such as PostgreSQL with pgvector."
+            )
           case _ => acc
         }
       }

--- a/build.sbt
+++ b/build.sbt
@@ -122,8 +122,10 @@ val testcontainersVersion: String = "2.0.5"
 
 val mongoVersion: String = "5.6.2"
 
+val qdrantVersion: String = "1.18.1"
+
 lazy val root = project.in(file("."))
-	.aggregate(core.jvm, traversal, sql, sqlite, postgresql, mariadb, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, arangodb, api, apiSpice, all)
+	.aggregate(core.jvm, traversal, sql, sqlite, postgresql, mariadb, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, arangodb, qdrant, api, apiSpice, all)
 	.settings(
 		name := projectName,
 		publish := {},
@@ -423,8 +425,21 @@ lazy val arangodb = project.in(file("arangodb"))
 		)
 	)
 
+lazy val qdrant = project.in(file("qdrant"))
+	.dependsOn(core.jvm, core.jvm % "test->test", traversal % "test->test")
+	.settings(
+		name := s"$projectName-qdrant",
+		fork := true,
+		Test / fork := true,
+		libraryDependencies ++= Seq(
+			"io.qdrant" % "client" % qdrantVersion,
+			"org.testcontainers" % "testcontainers" % testcontainersVersion % Test,
+			"org.scalatest" %% "scalatest" % scalaTestVersion % Test
+		)
+	)
+
 lazy val all = project.in(file("all"))
-	.dependsOn(core.jvm, core.jvm % "test->test", traversal, sqlite, postgresql, mariadb, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, arangodb, api, apiSpice)
+	.dependsOn(core.jvm, core.jvm % "test->test", traversal, sqlite, postgresql, mariadb, duckdb, h2, lucene, opensearch, halodb, rocksdb, mapdb, lmdb, chronicleMap, redis, googleSheets, tantivy, mongodb, arangodb, qdrant, api, apiSpice)
 	.settings(
 		name := s"$projectName-all",
 		fork := true,

--- a/core/src/main/scala/lightdb/Sort.scala
+++ b/core/src/main/scala/lightdb/Sort.scala
@@ -3,6 +3,7 @@ package lightdb
 import lightdb.doc.Document
 import lightdb.field.Field
 import lightdb.spatial.{Geo, Point}
+import lightdb.vector.VectorMetric
 
 trait Sort
 
@@ -33,5 +34,24 @@ object Sort {
     def asc: ByDistance[Doc, G] = direction(SortDirection.Ascending)
     def descending: ByDistance[Doc, G] = direction(SortDirection.Descending)
     def desc: ByDistance[Doc, G] = direction(SortDirection.Descending)
+  }
+
+  /**
+   * Nearest-neighbor (KNN) ordering by vector similarity. Combine with `.limit(k)` to retrieve the
+   * top-k most similar documents. Ascending (the default) returns the nearest first, since every
+   * [[VectorMetric]] is defined so that a smaller distance means more similar.
+   *
+   * Native on backends with vector support (e.g. PostgreSQL + pgvector); evaluated in-memory as a
+   * brute-force scan on backends without it.
+   */
+  case class ByVectorDistance[Doc <: Document[Doc]](field: Field[Doc, List[Double]],
+                                                    vector: List[Double],
+                                                    metric: VectorMetric,
+                                                    direction: SortDirection = SortDirection.Ascending) extends Sort {
+    def direction(direction: SortDirection): ByVectorDistance[Doc] = copy(direction = direction)
+    def ascending: ByVectorDistance[Doc] = direction(SortDirection.Ascending)
+    def asc: ByVectorDistance[Doc] = direction(SortDirection.Ascending)
+    def descending: ByVectorDistance[Doc] = direction(SortDirection.Descending)
+    def desc: ByVectorDistance[Doc] = direction(SortDirection.Descending)
   }
 }

--- a/core/src/main/scala/lightdb/doc/DocumentModel.scala
+++ b/core/src/main/scala/lightdb/doc/DocumentModel.scala
@@ -253,6 +253,18 @@ trait DocumentModel[Doc <: Document[Doc]] { model =>
 
     def unique[V: RW](get: Doc => V)(implicit name: Name): UniqueIndex[Doc, V] = unique(name.value, get)
 
+    def vector(name: String,
+               get: FieldGetter[Doc, List[Double]],
+               dimension: Int,
+               metric: lightdb.vector.VectorMetric): Field.VectorIndex[Doc] =
+      add[List[Double], Field.VectorIndex[Doc]](Field.vector(name, get, dimension, metric))
+
+    def vector(name: String,
+               get: Doc => List[Double],
+               dimension: Int,
+               metric: lightdb.vector.VectorMetric): Field.VectorIndex[Doc] =
+      add[List[Double], Field.VectorIndex[Doc]](Field.vector(name, FieldGetter.func(get), dimension, metric))
+
     def tokenized(name: String, get: FieldGetter[Doc, String]): Tokenized[Doc] =
       add[String, Tokenized[Doc]](Field.tokenized(name, get))
 

--- a/core/src/main/scala/lightdb/field/Field.scala
+++ b/core/src/main/scala/lightdb/field/Field.scala
@@ -38,6 +38,15 @@ sealed class Field[Doc <: Document[Doc], V](val name: String,
 
   lazy val isSpatial: Boolean = className.exists(_.startsWith("lightdb.spatial.Geo"))
 
+  /** Declared dimension of this vector field, or `None` if this is not a vector field. */
+  def vectorDimension: Option[Int] = None
+
+  /** Default similarity metric for this vector field, or `None` if this is not a vector field. */
+  def vectorMetric: Option[lightdb.vector.VectorMetric] = None
+
+  /** True when this field holds a vector/embedding eligible for KNN search (see [[Field.vector]]). */
+  lazy val isVector: Boolean = vectorDimension.isDefined
+
   def isTokenized: Boolean = false
 
   def getJson(doc: Doc, state: IndexingState): Json = get(doc, this, state).json
@@ -148,6 +157,25 @@ object Field {
     override def toString: String = s"NestedIndex(name = ${this.name}, path = $path)"
   }
 
+  def vector[Doc <: Document[Doc]](name: String,
+                                   get: FieldGetter[Doc, List[Double]],
+                                   dimension: Int,
+                                   metric: lightdb.vector.VectorMetric): VectorIndex[Doc] = {
+    val dim = dimension
+    val mtr = metric
+    new Field[Doc, List[Double]](
+      name = name,
+      get = get,
+      getRW = () => implicitly[RW[List[Double]]],
+      indexed = true,
+      stored = true
+    ) with VectorIndex[Doc] {
+      override val dimension: Int = dim
+      override val metric: lightdb.vector.VectorMetric = mtr
+      override def toString: String = s"VectorIndex(name = ${this.name}, dimension = $dim, metric = $mtr)"
+    }
+  }
+
   def tokenized[Doc <: Document[Doc]](name: String,
                                       get: FieldGetter[Doc, String]): Tokenized[Doc] = new Field[Doc, String](
     name = name,
@@ -222,6 +250,25 @@ object Field {
   }
 
   trait UniqueIndex[Doc <: Document[Doc], V] extends Indexed[Doc, V]
+
+  /**
+   * A vector/embedding field holding a `List[Double]` of fixed `dimension`, with a default similarity
+   * `metric`. Backends with native vector support (e.g. PostgreSQL + pgvector) emit a typed,
+   * ANN-indexed column; others fall back to an in-memory brute-force scan for KNN.
+   */
+  trait VectorIndex[Doc <: Document[Doc]] extends Indexed[Doc, List[Double]] {
+    def dimension: Int
+    def metric: lightdb.vector.VectorMetric
+
+    override def vectorDimension: Option[Int] = Some(dimension)
+    override def vectorMetric: Option[lightdb.vector.VectorMetric] = Some(metric)
+
+    /** Builds a KNN sort against this field for `vector`; combine with `.limit(k)` for top-k. */
+    def knn(vector: List[Double],
+            metric: lightdb.vector.VectorMetric = this.metric,
+            direction: lightdb.SortDirection = lightdb.SortDirection.Ascending): lightdb.Sort.ByVectorDistance[Doc] =
+      lightdb.Sort.ByVectorDistance(this, vector, metric, direction)
+  }
 
   trait Tokenized[Doc <: Document[Doc]] extends Indexed[Doc, String] {
     override def isTokenized: Boolean = true

--- a/core/src/main/scala/lightdb/vector/VectorMetric.scala
+++ b/core/src/main/scala/lightdb/vector/VectorMetric.scala
@@ -1,0 +1,25 @@
+package lightdb.vector
+
+/**
+ * Similarity metric for vector / embedding nearest-neighbor (KNN) search.
+ *
+ * Each metric defines a *distance* where a smaller value means more similar, so an ascending
+ * [[lightdb.Sort.ByVectorDistance]] returns the nearest neighbors first. Backends map the metric to
+ * their native operator/index (e.g. pgvector's `<=>` / `<->` / `<#>` and matching HNSW operator
+ * class). Vector search is a native-only capability — there is intentionally no in-memory emulation.
+ */
+sealed trait VectorMetric
+
+object VectorMetric {
+  /** Cosine distance (`1 - cosine_similarity`); range [0, 2], 0 = identical direction. pgvector `<=>`. */
+  case object Cosine extends VectorMetric
+
+  /** Euclidean (L2) distance. pgvector `<->`. */
+  case object Euclidean extends VectorMetric
+
+  /**
+   * Negative inner product, so that a larger dot product (more similar) yields a smaller distance and
+   * sorts first under ascending order. Mirrors pgvector `<#>` (which also returns the negative IP).
+   */
+  case object DotProduct extends VectorMetric
+}

--- a/lucene/src/main/scala/lightdb/lucene/LuceneSearchBuilder.scala
+++ b/lucene/src/main/scala/lightdb/lucene/LuceneSearchBuilder.scala
@@ -21,7 +21,7 @@ import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts
 import org.apache.lucene.facet.{DrillDownQuery, FacetsCollector, FacetsCollectorManager}
 import org.apache.lucene.index.{StoredFields, Term}
 import org.apache.lucene.search.grouping.{FirstPassGroupingCollector, SearchGroup, TermGroupSelector, TopGroups, TopGroupsCollector}
-import org.apache.lucene.search.{BooleanClause, BooleanQuery, BoostQuery, MatchAllDocsQuery, MatchNoDocsQuery, MultiCollectorManager, RegexpQuery, ScoreDoc, SortField, SortedNumericSortField, TermInSetQuery, TermQuery, TopFieldCollectorManager, TopFieldDocs, TotalHitCountCollectorManager, Query => LuceneQuery, Sort => LuceneSort}
+import org.apache.lucene.search.{BooleanClause, BooleanQuery, BoostQuery, IndexSearcher, KnnFloatVectorQuery, MatchAllDocsQuery, MatchNoDocsQuery, MultiCollectorManager, RegexpQuery, ScoreDoc, SortField, SortedNumericSortField, TermInSetQuery, TermQuery, TopFieldCollectorManager, TopFieldDocs, TotalHitCountCollectorManager, Query => LuceneQuery, Sort => LuceneSort}
 import org.apache.lucene.util.BytesRef
 import org.apache.lucene.util.automaton.RegExp
 import rapid.Task
@@ -56,11 +56,23 @@ class LuceneSearchBuilder[Doc <: Document[Doc], Model <: DocumentModel[Doc]](sto
 
   def apply[V](query: Query[Doc, Model, V]): Task[SearchResults[Doc, Model, V]] = Task {
     val indexSearcher = tx.state.indexSearcher
-    val q: LuceneQuery = filter2Lucene(query.filter).rewrite(indexSearcher)
-    val s: LuceneSort = sort(query.sort)
+    val knnSortOpt: Option[Sort.ByVectorDistance[_]] = query.sort.collectFirst {
+      case bv: Sort.ByVectorDistance[_] => bv
+    }
     val limit = query.limit.orElse(query.pageSize).getOrElse(100_000_000)   // TODO: Evaluate a configurable upper limit
     if limit <= 0 then throw new RuntimeException(s"Limit must be a positive value, but set to $limit")
     val max = limit + query.offset
+    // Native KNN: a vector sort becomes a KnnFloatVectorQuery (top-`max` nearest, with the regular
+    // filter applied as a pre-filter). Results are scored by similarity, so order by score (nearest
+    // first); Lucene KNN is nearest-only, so a descending vector sort is rejected.
+    val q: LuceneQuery = knnSortOpt match {
+      case Some(bv) => knnQuery(bv, max, query.filter, indexSearcher)
+      case None => filter2Lucene(query.filter).rewrite(indexSearcher)
+    }
+    val s: LuceneSort = knnSortOpt match {
+      case Some(_) => new LuceneSort(SortField.FIELD_SCORE)
+      case None => sort(query.sort)
+    }
 
     val collectors = List(
       Some(new TopFieldCollectorManager(s, max, max)),
@@ -380,11 +392,32 @@ class LuceneSearchBuilder[Doc <: Document[Doc], Model <: DocumentModel[Doc]](sto
         val fieldSortName = s"${parentFieldName(field.name)}Sort"
         LatLonDocValuesField.newDistanceSort(fieldSortName, from.latitude, from.longitude)
       case _: Sort.ByVectorDistance[_] =>
-        throw new UnsupportedOperationException(
-          "Vector search (Sort.ByVectorDistance) is not yet supported by the Lucene backend; " +
-            "use a backend with native vector support such as PostgreSQL with pgvector."
-        )
+        // Handled before sort() is called (see apply / knnQuery); never reached via sort2SortField.
+        throw new UnsupportedOperationException("Sort.ByVectorDistance must be handled as a KnnFloatVectorQuery")
     }
+  }
+
+  /**
+   * Builds a `KnnFloatVectorQuery` for a vector KNN sort: top-`k` nearest by the field's indexed
+   * similarity function, with the regular query filter applied as a pre-filter. Lucene KNN is
+   * nearest-first only, so a descending vector sort is rejected.
+   */
+  private def knnQuery(bv: Sort.ByVectorDistance[_],
+                       k: Int,
+                       filter: Option[Filter[Doc]],
+                       searcher: IndexSearcher): LuceneQuery = {
+    if bv.direction == SortDirection.Descending then {
+      throw new UnsupportedOperationException(
+        "Lucene vector search returns nearest-first only; a descending Sort.ByVectorDistance is not supported."
+      )
+    }
+    val fieldName = parentFieldName(bv.field.name)
+    val target = bv.vector.iterator.map(_.toFloat).toArray
+    val preFilter: LuceneQuery = filter match {
+      case Some(f) => filter2Lucene(Some(f)).rewrite(searcher)
+      case None => null
+    }
+    new KnnFloatVectorQuery(fieldName, target, k, preFilter)
   }
 
   def filter2Lucene(filter: Option[Filter[Doc]]): LuceneQuery = {

--- a/lucene/src/main/scala/lightdb/lucene/LuceneSearchBuilder.scala
+++ b/lucene/src/main/scala/lightdb/lucene/LuceneSearchBuilder.scala
@@ -379,6 +379,11 @@ class LuceneSearchBuilder[Doc <: Document[Doc], Model <: DocumentModel[Doc]](sto
       case Sort.ByDistance(field, from, _) =>
         val fieldSortName = s"${parentFieldName(field.name)}Sort"
         LatLonDocValuesField.newDistanceSort(fieldSortName, from.latitude, from.longitude)
+      case _: Sort.ByVectorDistance[_] =>
+        throw new UnsupportedOperationException(
+          "Vector search (Sort.ByVectorDistance) is not yet supported by the Lucene backend; " +
+            "use a backend with native vector support such as PostgreSQL with pgvector."
+        )
     }
   }
 

--- a/lucene/src/main/scala/lightdb/lucene/LuceneTransaction.scala
+++ b/lucene/src/main/scala/lightdb/lucene/LuceneTransaction.scala
@@ -19,10 +19,10 @@ import lightdb.transaction.{CollectionTransaction, NestedQueryTransaction, Rollb
 import lightdb.util.Aggregator
 import lightdb.{Query, SearchResults, Sort}
 import lightdb.lucene.blockjoin.{LuceneBlockJoinFields, LuceneBlockJoinStore}
-import org.apache.lucene.document.{DoubleDocValuesField, DoubleField, IntField, LatLonDocValuesField, LatLonPoint, LatLonShape, LongField, NumericDocValuesField, SortedDocValuesField, StoredField, StringField, TextField, Document => LuceneDocument, Field => LuceneField}
+import org.apache.lucene.document.{DoubleDocValuesField, DoubleField, IntField, KnnFloatVectorField, LatLonDocValuesField, LatLonPoint, LatLonShape, LongField, NumericDocValuesField, SortedDocValuesField, StoredField, StringField, TextField, Document => LuceneDocument, Field => LuceneField}
 import org.apache.lucene.facet.{FacetField => LuceneFacetField}
 import org.apache.lucene.geo.{Line => LuceneLine, Polygon => LucenePolygon}
-import org.apache.lucene.index.Term
+import org.apache.lucene.index.{Term, VectorSimilarityFunction}
 import org.apache.lucene.search.{BooleanClause, BooleanQuery, MatchAllDocsQuery, ScoreDoc, TermQuery}
 import org.apache.lucene.util.BytesRef
 import rapid.Task
@@ -266,7 +266,11 @@ case class LuceneTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]](
    * Otherwise we fall back to the default offset-based implementation.
    */
   override def streamScored[V](query: Query[Doc, Model, V]): rapid.Stream[(V, Double)] = {
-    if query.pageSize.nonEmpty && query.offset == 0 && !NestedQuerySupport.containsNested(query.filter) then {
+    if query.sort.exists(_.isInstanceOf[lightdb.Sort.ByVectorDistance[_]]) then {
+      // Vector KNN is inherently top-k: run the KnnFloatVectorQuery path once (see LuceneSearchBuilder),
+      // bypassing searchAfter / offset pagination which can't express a KNN query.
+      rapid.Stream.force(doSearchDirect(query).map(_.streamWithScore))
+    } else if query.pageSize.nonEmpty && query.offset == 0 && !NestedQuerySupport.containsNested(query.filter) then {
       val basePageSize = query.pageSize.getOrElse(1000)
 
       def loop(after: Option[ScoreDoc], remaining: Option[Int]): rapid.Stream[(V, Double)] =
@@ -566,6 +570,20 @@ case class LuceneTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]](
       }
       case t: Tokenized[Doc] =>
         List(new LuceneField(field.name, t.get(doc, t, state), if fs == LuceneField.Store.YES then TextField.TYPE_STORED else TextField.TYPE_NOT_STORED))
+      case vi: Field.VectorIndex[Doc @unchecked] =>
+        // Native KNN: index the embedding as a HNSW float-vector field, and store the JSON so the
+        // value round-trips back into the document's List[Double].
+        if json != Null then {
+          val target = json.asVector.map(_.asDouble.toFloat).toArray
+          val similarity = vi.metric match {
+            case lightdb.vector.VectorMetric.Cosine => VectorSimilarityFunction.COSINE
+            case lightdb.vector.VectorMetric.Euclidean => VectorSimilarityFunction.EUCLIDEAN
+            case lightdb.vector.VectorMetric.DotProduct => VectorSimilarityFunction.DOT_PRODUCT
+          }
+          add(new KnnFloatVectorField(field.name, target, similarity))
+        }
+        add(new StoredField(field.name, JsonFormatter.Compact(json)))
+        fields
       case _ =>
         def addJson(json: Json, d: DefType): Unit = {
           if field.isSpatial then {

--- a/lucene/src/test/scala/spec/LuceneVectorSpec.scala
+++ b/lucene/src/test/scala/spec/LuceneVectorSpec.scala
@@ -1,0 +1,81 @@
+package spec
+
+import fabric.rw.*
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel, JsonConversion}
+import lightdb.field.Field
+import lightdb.id.Id
+import lightdb.lucene.LuceneStore
+import lightdb.upgrade.DatabaseUpgrade
+import lightdb.vector.VectorMetric
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import rapid.AsyncTaskSpec
+
+/** Verifies native Lucene KNN: a KnnFloatVectorField (HNSW) + a KnnFloatVectorQuery for top-k search. */
+@EmbeddedTest
+class LuceneVectorSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers {
+  private val apple = Id[VDoc]("apple")
+  private val almostApple = Id[VDoc]("almostApple")
+  private val banana = Id[VDoc]("banana")
+  private val car = Id[VDoc]("car")
+
+  private val query = List(1.0, 0.0, 0.0)
+
+  "Lucene KNN" should {
+    "initialize" in {
+      DB.init.succeed
+    }
+    "insert documents with embeddings" in {
+      DB.docs.transaction(_.insert(List(
+        VDoc("apple", "fruit", List(1.0, 0.0, 0.0), apple),
+        VDoc("almost apple", "fruit", List(0.9, 0.1, 0.0), almostApple),
+        VDoc("banana", "fruit", List(0.0, 1.0, 0.0), banana),
+        VDoc("car", "vehicle", List(0.0, 0.0, 1.0), car)
+      ))).map(_ => succeed)
+    }
+    "round-trip an embedding through the stored value" in {
+      DB.docs.transaction { tx =>
+        tx(apple).map { doc =>
+          doc.embedding should be(List(1.0, 0.0, 0.0))
+        }
+      }
+    }
+    "return the nearest neighbors in order (cosine)" in {
+      DB.docs.transaction { tx =>
+        tx.query.sort(VDoc.embedding.knn(query)).limit(2).toList.map { docs =>
+          docs.map(_._id) should be(List(apple, almostApple))
+        }
+      }
+    }
+    "support hybrid search (filter + KNN)" in {
+      DB.docs.transaction { tx =>
+        tx.query.filter(_.category === "vehicle").sort(VDoc.embedding.knn(query)).limit(5).toList.map { docs =>
+          docs.map(_._id) should be(List(car))
+        }
+      }
+    }
+    "dispose" in {
+      DB.truncate().flatMap(_ => DB.dispose).succeed
+    }
+  }
+
+  case class VDoc(text: String, category: String, embedding: List[Double], _id: Id[VDoc] = Id()) extends Document[VDoc]
+
+  object VDoc extends DocumentModel[VDoc] with JsonConversion[VDoc] {
+    override implicit val rw: RW[VDoc] = RW.gen
+
+    val text: I[String] = field.index("text", _.text)
+    val category: I[String] = field.index("category", _.category)
+    val embedding: Field.VectorIndex[VDoc] = field.vector("embedding", _.embedding, dimension = 3, metric = VectorMetric.Cosine)
+  }
+
+  object DB extends LightDB {
+    override type SM = LuceneStore.type
+    override val storeManager: LuceneStore.type = LuceneStore
+    override def name: String = "LuceneVectorSpec"
+    override lazy val directory: Option[java.nio.file.Path] = None
+    val docs: lightdb.store.Collection[VDoc, VDoc.type] = store[VDoc, VDoc.type](VDoc)()
+    override def upgrades: List[DatabaseUpgrade] = Nil
+  }
+}

--- a/mongodb/src/main/scala/lightdb/mongodb/MongoDBTransaction.scala
+++ b/mongodb/src/main/scala/lightdb/mongodb/MongoDBTransaction.scala
@@ -217,6 +217,11 @@ case class MongoDBTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
             val field = bf.field.asInstanceOf[Field[Doc, Any]]
             val sorted = acc.sortBy(d => field.getJson(d, state))(jsonOrdering)
             if (bf.direction == lightdb.SortDirection.Descending) sorted.reverse else sorted
+          case _: lightdb.Sort.ByVectorDistance[_] =>
+            throw new UnsupportedOperationException(
+              "Vector search (Sort.ByVectorDistance) is not supported by the MongoDB backend; " +
+                "use a backend with native vector support such as PostgreSQL with pgvector."
+            )
           case _ => acc
         }
       }

--- a/opensearch/src/main/scala/lightdb/opensearch/query/OpenSearchSearchBuilder.scala
+++ b/opensearch/src/main/scala/lightdb/opensearch/query/OpenSearchSearchBuilder.scala
@@ -694,6 +694,11 @@ class OpenSearchSearchBuilder[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
           "order" -> str(order),
           "unit" -> str("m")
         ))
+      case _: Sort.ByVectorDistance[_] =>
+        throw new UnsupportedOperationException(
+          "Vector search (Sort.ByVectorDistance) is not supported by the OpenSearch backend; " +
+            "use a backend with native vector support such as PostgreSQL with pgvector."
+        )
     }
   }
 

--- a/postgresql/src/main/scala/lightdb/postgresql/PostgreSQLStore.scala
+++ b/postgresql/src/main/scala/lightdb/postgresql/PostgreSQLStore.scala
@@ -32,6 +32,11 @@ class PostgreSQLStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: S
     try {
       // Create pg_trgm to support extremely large columns with efficient filtering
       s.executeUpdate("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+      // pgvector is required only when the model declares a vector field; enabling it lets the
+      // `vector(N)` columns and HNSW indexes below be created.
+      if (fields.exists(_.isVector)) {
+        s.executeUpdate("CREATE EXTENSION IF NOT EXISTS vector")
+      }
     } finally {
       s.close()
     }
@@ -40,6 +45,14 @@ class PostgreSQLStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: S
   override protected def createIndexSQL(index: Field.Indexed[Doc, _]): String = {
     val col = SqlIdent.quote(index.name)
     index match {
+      case vi: Field.VectorIndex[Doc @unchecked] =>
+        // HNSW approximate-nearest-neighbor index, with the operator class matching the field's metric.
+        val ops = vi.metric match {
+          case lightdb.vector.VectorMetric.Cosine => "vector_cosine_ops"
+          case lightdb.vector.VectorMetric.Euclidean => "vector_l2_ops"
+          case lightdb.vector.VectorMetric.DotProduct => "vector_ip_ops"
+        }
+        s"CREATE INDEX IF NOT EXISTS ${SqlIdent.quote(s"${name}_${index.name}_idx")} ON $fqn USING hnsw ($col $ops)"
       case _: Field.Tokenized[Doc @unchecked] =>
         // Use trigram GIN index for tokenized fields to accelerate ILIKE/LIKE searches
         s"CREATE INDEX IF NOT EXISTS ${SqlIdent.quote(s"${name}_${index.name}_trgm_idx")} ON $fqn USING gin ($col gin_trgm_ops)"
@@ -76,6 +89,9 @@ class PostgreSQLStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: S
     }
   }
 
+  override protected def columnType(field: Field[Doc, _]): String =
+    if field.isVector then s"vector(${field.vectorDimension.get})" else super.columnType(field)
+
   override protected def def2Type(name: String, d: Definition): String = d.defType match {
     case DefType.Dec => "DOUBLE PRECISION"
     case DefType.Bool => "BOOLEAN"
@@ -106,6 +122,7 @@ class PostgreSQLStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: S
   }
 
   override protected def field2Value(field: Field[Doc, _]): String = {
+    if (field.isVector) return "?::vector"
     def lookup(definition: Definition): String = definition.defType match {
       case DefType.Opt(inner) => lookup(inner)
       case DefType.Dec => "?::double precision"

--- a/postgresql/src/main/scala/lightdb/postgresql/PostgreSQLTransaction.scala
+++ b/postgresql/src/main/scala/lightdb/postgresql/PostgreSQLTransaction.scala
@@ -2,10 +2,12 @@ package lightdb.postgresql
 
 import fabric.*
 import fabric.rw.*
+import lightdb.Sort
 import lightdb.doc.{Document, DocumentModel}
 import lightdb.sql.query.SQLPart
-import lightdb.sql.{SQLState, SQLStoreTransaction}
+import lightdb.sql.{SQLState, SQLStoreTransaction, SqlIdent}
 import lightdb.transaction.Transaction
+import lightdb.vector.VectorMetric
 
 import java.sql.PreparedStatement
 
@@ -31,5 +33,24 @@ case class PostgreSQLTransaction[Doc <: Document[Doc], Model <: DocumentModel[Do
   override def populate(ps: PreparedStatement, arg: Json, index: Int): Unit = arg match {
     case Bool(b, _) => ps.setBoolean(index + 1, b)
     case _ => super.populate(ps, arg, index)
+  }
+
+  // pgvector columns surface through JDBC as a PGobject whose text value is the vector literal
+  // (e.g. "[1,2,3]"). Unwrap it to the String so the generic row→doc path parses it back into a List.
+  override protected def obj2Value(obj: Any): Any = obj match {
+    case pg: org.postgresql.util.PGobject => pg.getValue
+    case _ => super.obj2Value(obj)
+  }
+
+  // KNN distance pseudo-column, bound to the query vector and ordered by alias (see sortByVectorDistance).
+  override protected def extraFieldsForVectorDistance(sort: Sort.ByVectorDistance[Doc]): List[SQLPart] = {
+    val col = SqlIdent.quote(sort.field.name)
+    val alias = SqlIdent.quote(s"${sort.field.name}VectorDistance")
+    val op = sort.metric match {
+      case VectorMetric.Cosine => "<=>"
+      case VectorMetric.Euclidean => "<->"
+      case VectorMetric.DotProduct => "<#>"
+    }
+    List(SQLPart(s"$col $op ?::vector AS $alias", sort.vector.json))
   }
 }

--- a/postgresql/src/test/scala/spec/PgVectorAvailability.scala
+++ b/postgresql/src/test/scala/spec/PgVectorAvailability.scala
@@ -1,0 +1,14 @@
+package spec
+
+import org.scalatest.{AsyncTestSuite, FutureOutcome}
+
+/**
+ * Cancels (rather than fails) every test in a pgvector-backed spec when no pgvector container can be
+ * started (Docker/Testcontainers unavailable). Mirrors [[PostgreSQLAvailability]].
+ */
+trait PgVectorAvailability extends AsyncTestSuite {
+  abstract override def withFixture(test: NoArgAsyncTest): FutureOutcome =
+    if PgVectorTestSupport.jdbcUrl.isEmpty then
+      FutureOutcome.canceled("pgvector unavailable — Docker/Testcontainers not available. Skipping.")
+    else super.withFixture(test)
+}

--- a/postgresql/src/test/scala/spec/PgVectorTestContainer.scala
+++ b/postgresql/src/test/scala/spec/PgVectorTestContainer.scala
@@ -1,0 +1,47 @@
+package spec
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import fabric.rw.stringRW
+import profig.Profig
+
+import java.time.Duration
+
+/**
+ * Lazily starts a pgvector-enabled PostgreSQL container (the official `pgvector/pgvector` image, a
+ * drop-in PostgreSQL with the `vector` extension available) for vector/KNN specs, and tears it down
+ * at JVM exit. Unlike [[PostgreSQLTestContainer]] this does not probe for a local server, since a
+ * plain local PostgreSQL would lack the extension. Image overridable via the
+ * `lightdb.pgvector.testcontainers.image` Profig key.
+ */
+private[spec] object PgVectorTestContainer {
+  private val Port = 5432
+
+  private class Container(image: DockerImageName) extends GenericContainer[Container](image)
+
+  private lazy val container: Container = {
+    val image = Profig("lightdb.pgvector.testcontainers.image").opt[String].getOrElse("pgvector/pgvector:pg17")
+    val c = new Container(DockerImageName.parse(image).asCompatibleSubstituteFor("postgres"))
+    c.withExposedPorts(Port)
+    c.withEnv("POSTGRES_DB", "basic")
+    c.withEnv("POSTGRES_USER", "postgres")
+    c.withEnv("POSTGRES_PASSWORD", "password")
+    // postgres logs this line twice (init, then the real start) — wait for the second.
+    c.waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*", 2).withStartupTimeout(Duration.ofMinutes(2)))
+    c
+  }
+
+  private lazy val started: Unit = {
+    container.start()
+    Runtime.getRuntime.addShutdownHook(new Thread(() => {
+      try container.stop()
+      catch { case _: Throwable => () }
+    }))
+  }
+
+  def jdbcUrl: String = {
+    started
+    s"jdbc:postgresql://${container.getHost}:${container.getMappedPort(Port)}/basic"
+  }
+}

--- a/postgresql/src/test/scala/spec/PgVectorTestSupport.scala
+++ b/postgresql/src/test/scala/spec/PgVectorTestSupport.scala
@@ -1,0 +1,26 @@
+package spec
+
+import lightdb.postgresql.PostgreSQLStoreManager
+import lightdb.sql.connect.{HikariConnectionManager, SQLConfig}
+
+/**
+ * Resolves a pgvector-enabled PostgreSQL for KNN specs via an ephemeral Testcontainers instance
+ * (auto-removed at JVM exit). Yields `None` when Docker is unavailable so specs cancel gracefully
+ * (see [[PgVectorAvailability]]).
+ */
+object PgVectorTestSupport {
+  val username = "postgres"
+  val password = "password"
+
+  lazy val jdbcUrl: Option[String] =
+    try Some(PgVectorTestContainer.jdbcUrl)
+    catch {
+      case t: Throwable =>
+        scribe.warn(s"pgvector unavailable: Testcontainers failed to start (${t.getMessage})")
+        None
+    }
+
+  def sqlConfig: SQLConfig = SQLConfig(jdbcUrl = jdbcUrl.get, username = Some(username), password = Some(password))
+
+  def storeManager: PostgreSQLStoreManager = PostgreSQLStoreManager(HikariConnectionManager(sqlConfig))
+}

--- a/postgresql/src/test/scala/spec/PostgreSQLVectorSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLVectorSpec.scala
@@ -1,0 +1,92 @@
+package spec
+
+import fabric.rw.*
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel, JsonConversion}
+import lightdb.field.Field
+import lightdb.id.Id
+import lightdb.postgresql.{PostgreSQLStore, PostgreSQLStoreManager}
+import lightdb.upgrade.DatabaseUpgrade
+import lightdb.vector.VectorMetric
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import rapid.AsyncTaskSpec
+
+import java.nio.file.Path
+
+/** Verifies native pgvector KNN: a `vector(N)` column, an HNSW index, and `ORDER BY emb <=> ?`. */
+@EmbeddedTest
+class PostgreSQLVectorSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with PgVectorAvailability {
+  private val apple = Id[VDoc]("apple")
+  private val almostApple = Id[VDoc]("almostApple")
+  private val banana = Id[VDoc]("banana")
+  private val car = Id[VDoc]("car")
+
+  private val query = List(1.0, 0.0, 0.0)
+
+  "pgvector KNN" should {
+    "initialize" in {
+      DB.init.succeed
+    }
+    "insert documents with embeddings" in {
+      DB.docs.transaction { tx =>
+        tx.insert(List(
+          VDoc("apple", "fruit", List(1.0, 0.0, 0.0), apple),
+          VDoc("almost apple", "fruit", List(0.9, 0.1, 0.0), almostApple),
+          VDoc("banana", "fruit", List(0.0, 1.0, 0.0), banana),
+          VDoc("car", "vehicle", List(0.0, 0.0, 1.0), car)
+        )).map(_ => succeed)
+      }
+    }
+    "round-trip an embedding through the vector column" in {
+      DB.docs.transaction { tx =>
+        tx(apple).map { doc =>
+          doc.embedding should be(List(1.0, 0.0, 0.0))
+        }
+      }
+    }
+    "return the nearest neighbors in order (cosine)" in {
+      DB.docs.transaction { tx =>
+        tx.query.sort(VDoc.embedding.knn(query)).limit(2).toList.map { docs =>
+          docs.map(_._id) should be(List(apple, almostApple))
+        }
+      }
+    }
+    "support hybrid search (filter + KNN)" in {
+      DB.docs.transaction { tx =>
+        tx.query.filter(_.category === "vehicle").sort(VDoc.embedding.knn(query)).limit(5).toList.map { docs =>
+          docs.map(_._id) should be(List(car))
+        }
+      }
+    }
+    "order farthest-first when descending" in {
+      DB.docs.transaction { tx =>
+        tx.query.sort(VDoc.embedding.knn(query).descending).limit(1).toList.map { docs =>
+          docs.map(_._id).head should (be(banana) or be(car)) // both at cosine distance 1.0 from query
+        }
+      }
+    }
+    "dispose" in {
+      DB.truncate().flatMap(_ => DB.dispose).succeed
+    }
+  }
+
+  case class VDoc(text: String, category: String, embedding: List[Double], _id: Id[VDoc] = Id()) extends Document[VDoc]
+
+  object VDoc extends DocumentModel[VDoc] with JsonConversion[VDoc] {
+    override implicit val rw: RW[VDoc] = RW.gen
+
+    val text: I[String] = field.index("text", _.text)
+    val category: I[String] = field.index("category", _.category)
+    val embedding: Field.VectorIndex[VDoc] = field.vector("embedding", _.embedding, dimension = 3, metric = VectorMetric.Cosine)
+  }
+
+  object DB extends LightDB {
+    override type SM = PostgreSQLStoreManager
+    override val storeManager: PostgreSQLStoreManager = PgVectorTestSupport.storeManager
+    override def name: String = "PostgreSQLVectorSpec"
+    override lazy val directory: Option[Path] = None
+    val docs: PostgreSQLStore[VDoc, VDoc.type] = store(VDoc)()
+    override def upgrades: List[DatabaseUpgrade] = Nil
+  }
+}

--- a/qdrant/src/main/scala/lightdb/qdrant/QdrantStore.scala
+++ b/qdrant/src/main/scala/lightdb/qdrant/QdrantStore.scala
@@ -1,0 +1,102 @@
+package lightdb.qdrant
+
+import io.qdrant.client.{QdrantClient, QdrantGrpcClient}
+import io.qdrant.client.grpc.Collections.{Distance, VectorParams}
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel}
+import lightdb.field.Field
+import lightdb.store.{Collection, CollectionManager, StoreManager, StoreMode}
+import lightdb.transaction.Transaction
+import lightdb.transaction.batch.BatchConfig
+import lightdb.vector.VectorMetric
+import rapid.*
+
+import java.nio.file.Path
+
+/** Connection coordinates for a Qdrant server (gRPC, default port 6334). */
+case class QdrantConfig(host: String, port: Int = 6334, useTls: Boolean = false, apiKey: Option[String] = None)
+
+/**
+ * `Collection` backed by a Qdrant collection — a vector-first store.
+ *
+ * Qdrant is purpose-built for vector KNN, which it serves natively (see [[QdrantTransaction]]); it is
+ * intentionally NOT a general query engine here. A model's single [[Field.VectorIndex]] becomes the
+ * Qdrant point vector; every document field is stored in the point payload (the full document as JSON
+ * for exact round-trip, plus indexed scalar fields for filter push-down). Each LightDB document maps
+ * to one point whose id is a deterministic UUID derived from the document `_id`.
+ *
+ * Limitations (by design — Qdrant's strength is vectors, not general storage):
+ *  - no prefix scan, so it is not a `PrefixScanningStore` and cannot back the traversal/graph DSL;
+ *  - only equality (and simple AND) filters push down to Qdrant; richer predicates and all non-KNN
+ *    sorting are evaluated in-memory over a scroll of matching points.
+ *
+ * Models without a vector field still work as a plain key/value collection (a size-1 placeholder
+ * vector is used); KNN is only available when a vector field is declared.
+ */
+class QdrantStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: String,
+                                                                     path: Option[Path],
+                                                                     model: Model,
+                                                                     val storeMode: StoreMode[Doc, Model],
+                                                                     config: QdrantConfig,
+                                                                     db: LightDB,
+                                                                     storeManager: StoreManager) extends Collection[Doc, Model](name, path, model, db, storeManager) {
+  override type TX = QdrantTransaction[Doc, Model]
+
+  // The Qdrant gRPC client maintains its own connection; one per store, closed on dispose.
+  private lazy val client: QdrantClient = {
+    val builder = QdrantGrpcClient.newBuilder(config.host, config.port, config.useTls)
+    config.apiKey.foreach(builder.withApiKey)
+    new QdrantClient(builder.build())
+  }
+  private[qdrant] def qdrant: QdrantClient = client
+
+  // Qdrant collection names are safest starting with a letter; prefix anything else (e.g. LightDB's
+  // internal `_backingStore`).
+  private[qdrant] lazy val collectionName: String =
+    if name.headOption.exists(_.isLetter) then name else s"c$name"
+
+  /** The single vector field, if the model declares one. Qdrant points carry one (unnamed) vector. */
+  private[qdrant] lazy val vectorField: Option[Field.VectorIndex[Doc]] =
+    fields.collectFirst { case vi: Field.VectorIndex[Doc @unchecked] => vi }
+
+  private[qdrant] def vectorSize: Int = vectorField.map(_.dimension).getOrElse(1)
+
+  private[qdrant] def distance: Distance = vectorField.map(_.metric) match {
+    case Some(VectorMetric.Cosine) => Distance.Cosine
+    case Some(VectorMetric.Euclidean) => Distance.Euclid
+    case Some(VectorMetric.DotProduct) => Distance.Dot
+    case None => Distance.Euclid // placeholder vector for non-vector models
+  }
+
+  // Buffered batching so bulk loads coalesce into a single Qdrant upsert (see applyWriteOps).
+  override def defaultBatchConfig: BatchConfig = BatchConfig.Buffered()
+
+  override protected def initialize(): Task[Unit] = super.initialize().next(Task {
+    if (!client.collectionExistsAsync(collectionName).get().booleanValue()) {
+      val params = VectorParams.newBuilder().setSize(vectorSize.toLong).setDistance(distance).build()
+      client.createCollectionAsync(collectionName, params).get()
+    }
+  })
+
+  override protected def createTransaction(parent: Option[Transaction[Doc, Model]],
+                                           batchConfig: BatchConfig,
+                                           writeHandlerFactory: Transaction[Doc, Model] => lightdb.transaction.WriteHandler[Doc, Model]): Task[TX] =
+    Task(QdrantTransaction(this, parent, writeHandlerFactory))
+
+  override protected def doDispose(): Task[Unit] = super.doDispose().next(Task(client.close()))
+}
+
+/**
+ * Factory for [[QdrantStore]] instances. Each LightDB store maps to one Qdrant collection (named by
+ * the store name).
+ */
+case class QdrantStoreManager(config: QdrantConfig) extends CollectionManager {
+  override type S[Doc <: Document[Doc], Model <: DocumentModel[Doc]] = QdrantStore[Doc, Model]
+
+  override def create[Doc <: Document[Doc], Model <: DocumentModel[Doc]](db: LightDB,
+                                                                         model: Model,
+                                                                         name: String,
+                                                                         path: Option[Path],
+                                                                         storeMode: StoreMode[Doc, Model]): QdrantStore[Doc, Model] =
+    new QdrantStore[Doc, Model](name, path, model, storeMode, config, db, this)
+}

--- a/qdrant/src/main/scala/lightdb/qdrant/QdrantTransaction.scala
+++ b/qdrant/src/main/scala/lightdb/qdrant/QdrantTransaction.scala
@@ -1,0 +1,328 @@
+package lightdb.qdrant
+
+import fabric.*
+import fabric.io.{JsonFormatter, JsonParser}
+import fabric.rw.*
+import _root_.io.qdrant.client.{ConditionFactory, PointIdFactory, ValueFactory, VectorsFactory, WithPayloadSelectorFactory}
+import _root_.io.qdrant.client.grpc.Common.{Condition => QCondition, Filter => QFilter, PointId}
+import _root_.io.qdrant.client.grpc.JsonWithInt.Value
+import _root_.io.qdrant.client.grpc.Points.{PointStruct, ScrollPoints, SearchPoints}
+import lightdb.aggregate.AggregateQuery
+import lightdb.doc.{Document, DocumentModel}
+import lightdb.error.DuplicateIdException
+import lightdb.facet.{FacetComputation, FacetResult}
+import lightdb.field.{Field, IndexingState}
+import lightdb.filter.{Condition, Filter, FilterPlanner, NestedQuerySupport, QueryOptimizer}
+import lightdb.id.Id
+import lightdb.materialized.{MaterializedAggregate, MaterializedAndDoc, MaterializedIndex}
+import lightdb.store.Conversion
+import lightdb.store.write.WriteOp
+import lightdb.transaction.CollectionTransaction
+import lightdb.{Query, SearchResults, Sort, SortDirection}
+import rapid.Task
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import scala.jdk.CollectionConverters.*
+
+case class QdrantTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]](
+  store: QdrantStore[Doc, Model],
+  parent: Option[lightdb.transaction.Transaction[Doc, Model]],
+  writeHandlerFactory: lightdb.transaction.Transaction[Doc, Model] => lightdb.transaction.WriteHandler[Doc, Model]
+) extends CollectionTransaction[Doc, Model] {
+  override lazy val writeHandler: lightdb.transaction.WriteHandler[Doc, Model] = writeHandlerFactory(this)
+
+  private def client = store.qdrant
+  private def coll = store.collectionName
+
+  // The document's `_id` is an arbitrary string but Qdrant point ids must be UUID/uint64; derive a
+  // stable UUID so get/delete are O(1) lookups.
+  private def pointId(id: Id[Doc]): PointId =
+    PointIdFactory.id(UUID.nameUUIDFromBytes(s"lightdb:${id.value}".getBytes(StandardCharsets.UTF_8)))
+
+  // -- Json <-> payload ------------------------------------------------------------------------------
+
+  private def jsonToValue(json: Json): Value = json match {
+    case Str(s, _) => ValueFactory.value(s)
+    case NumInt(l, _) => ValueFactory.value(l)
+    case NumDec(d, _) => ValueFactory.value(d.toDouble)
+    case Bool(b, _) => ValueFactory.value(b)
+    case Null => ValueFactory.nullValue()
+    case Arr(v, _) => ValueFactory.value(v.map(jsonToValue).asJava)
+    case o: Obj => ValueFactory.value(o.value.map { case (k, v) => k -> jsonToValue(v) }.asJava)
+  }
+
+  /**
+   * Payload = the full document JSON under `__doc` (for exact round-trip) plus each indexed scalar
+   * field as its own key (so equality filters can push down to Qdrant).
+   */
+  private def toPoint(doc: Doc): PointStruct = {
+    val state = new IndexingState
+    val docJson = doc.json(store.model.rw)
+    val payload = scala.collection.mutable.Map.empty[String, Value]
+    payload.put("__doc", ValueFactory.value(JsonFormatter.Compact(docJson)))
+    store.fields.filter(f => f.indexed && !f.isVector).foreach { f =>
+      f.getJson(doc, state) match {
+        case v @ (_: Str | _: NumInt | _: NumDec | _: Bool) => payload.put(f.name, jsonToValue(v))
+        case _ => // non-scalar fields are not individually filterable; they remain in __doc
+      }
+    }
+    val vectors = store.vectorField match {
+      case Some(vf) => VectorsFactory.vectors(vf.get(doc, vf, state).map(d => java.lang.Float.valueOf(d.toFloat)).asJava)
+      case None => VectorsFactory.vectors(0.0f) // placeholder for non-vector models
+    }
+    PointStruct.newBuilder().setId(pointId(doc._id)).setVectors(vectors).putAllPayload(payload.asJava).build()
+  }
+
+  private def fromPayload(payload: java.util.Map[String, Value]): Doc =
+    JsonParser(payload.get("__doc").getStringValue).as[Doc](store.model.rw)
+
+  // -- Filter push-down ------------------------------------------------------------------------------
+
+  /** Translates an equality predicate on a scalar field into a Qdrant condition, when possible. */
+  private def pushCondition(f: Filter[Doc]): Option[QCondition] = f match {
+    case e: Filter.Equals[Doc, _] if !e.field(store.model).isVector =>
+      e.getJson(store.model) match {
+        case Str(s, _) => Some(ConditionFactory.matchKeyword(e.fieldName, s))
+        case NumInt(l, _) => Some(ConditionFactory.`match`(e.fieldName, l))
+        case Bool(b, _) => Some(ConditionFactory.`match`(e.fieldName, b))
+        case _ => None
+      }
+    case _ => None
+  }
+
+  /** (Qdrant filter to push, whether it fully expresses the LightDB filter). */
+  private def translateFilter(filter: Option[Filter[Doc]]): (Option[QFilter], Boolean) = filter match {
+    case None => (None, true)
+    case Some(m: Filter.Multi[Doc]) =>
+      val pushed = m.filters.map(fc => if fc.condition == Condition.Must then pushCondition(fc.filter) else None)
+      if pushed.nonEmpty && pushed.forall(_.isDefined) then {
+        (Some(pushed.flatten.foldLeft(QFilter.newBuilder())((b, c) => b.addMust(c)).build()), true)
+      } else (None, false)
+    case Some(f) =>
+      pushCondition(f) match {
+        case Some(c) => (Some(QFilter.newBuilder().addMust(c).build()), true)
+        case None => (None, false)
+      }
+  }
+
+  // -- KV contract -----------------------------------------------------------------------------------
+
+  private def existsSync(id: Id[Doc]): Boolean =
+    client.retrieveAsync(coll, java.util.List.of(pointId(id)), false, false, null).get().asScala.nonEmpty
+
+  override def jsonStream: rapid.Stream[Json] =
+    rapid.Stream.fromIterator(Task(scrollDocs(None).iterator.map(_.json(store.model.rw))))
+
+  override protected def _get[V](index: Field.UniqueIndex[Doc, V], value: V): Task[Option[Doc]] = Task {
+    if (index == store.idField) {
+      client.retrieveAsync(coll, java.util.List.of(pointId(value.asInstanceOf[Id[Doc]])), true, false, null)
+        .get().asScala.headOption.map(p => fromPayload(p.getPayloadMap))
+    } else {
+      pushCondition(Filter.Equals[Doc, V](index.name, value)) match {
+        case Some(c) => scrollDocs(Some(QFilter.newBuilder().addMust(c).build())).headOption
+        case None =>
+          val state = new IndexingState
+          scrollDocs(None).find(d => index.get(d, index, state) == value)
+      }
+    }
+  }
+
+  override protected def _insert(doc: Doc): Task[Doc] = Task {
+    if (existsSync(doc._id)) throw DuplicateIdException(store.name, doc._id)
+    client.upsertAsync(coll, java.util.List.of(toPoint(doc))).get()
+    doc
+  }
+
+  override protected def _upsert(doc: Doc): Task[Doc] = Task {
+    client.upsertAsync(coll, java.util.List.of(toPoint(doc))).get()
+    doc
+  }
+
+  override protected def _exists(id: Id[Doc]): Task[Boolean] = Task(existsSync(id))
+
+  override protected def _count: Task[Int] = Task(client.countAsync(coll).get().intValue())
+
+  override protected def _delete(id: Id[Doc]): Task[Boolean] = Task {
+    val existed = existsSync(id)
+    if (existed) client.deleteAsync(coll, java.util.List.of(pointId(id))).get()
+    existed
+  }
+
+  override protected def _commit: Task[Unit] = Task.unit
+  override protected def _rollback: Task[Unit] = Task.unit
+  override protected def _close: Task[Unit] = Task.unit
+
+  override def truncate: Task[Int] = Task {
+    val count = client.countAsync(coll).get().intValue()
+    // An empty filter matches all points.
+    client.deleteAsync(coll, QFilter.newBuilder().build()).get()
+    count
+  }
+
+  override private[lightdb] def applyWriteOps(ops: Seq[WriteOp[Doc]]): Task[Unit] = Task {
+    if (ops.nonEmpty) {
+      val upserts = ops.collect {
+        case WriteOp.Insert(doc) => toPoint(doc)
+        case WriteOp.Upsert(doc) => toPoint(doc)
+      }
+      val deletes = ops.collect { case WriteOp.Delete(id) => pointId(id) }
+      if (upserts.nonEmpty) client.upsertAsync(coll, upserts.asJava).get()
+      if (deletes.nonEmpty) client.deleteAsync(coll, deletes.asJava).get()
+      if (store.cache.isDefined) ops.foreach {
+        case WriteOp.Insert(doc) => cachePending.put(doc._id, Some(doc))
+        case WriteOp.Upsert(doc) => cachePending.put(doc._id, Some(doc))
+        case WriteOp.Delete(id) => cachePending.put(id, None)
+      }
+    }
+  }
+
+  // -- Query surface ---------------------------------------------------------------------------------
+
+  private def scrollDocs(filter: Option[QFilter]): List[Doc] = {
+    val buffer = scala.collection.mutable.ListBuffer.empty[Doc]
+    var offset: Option[PointId] = None
+    var continue = true
+    while (continue) {
+      val b = ScrollPoints.newBuilder()
+        .setCollectionName(coll)
+        .setLimit(256)
+        .setWithPayload(WithPayloadSelectorFactory.enable(true))
+      filter.foreach(b.setFilter)
+      offset.foreach(b.setOffset)
+      val response = client.scrollAsync(b.build()).get()
+      response.getResultList.asScala.foreach(p => buffer += fromPayload(p.getPayloadMap))
+      if (response.hasNextPageOffset) offset = Some(response.getNextPageOffset) else continue = false
+    }
+    buffer.toList
+  }
+
+  override def doSearch[V](query: Query[Doc, Model, V]): Task[SearchResults[Doc, Model, V]] =
+    FilterPlanner.resolve(query.filter, store.model, resolveExistsChild = !store.supportsNativeExistsChild).flatMap { resolved =>
+      val effective = if (query.optimize) resolved.map(QueryOptimizer.optimize) else resolved
+      query.sort.collectFirst { case bv: Sort.ByVectorDistance[_] => bv } match {
+        case Some(bv) => executeKnn(query, effective, bv.asInstanceOf[Sort.ByVectorDistance[Doc]])
+        case None => executeScroll(query, effective)
+      }
+    }
+
+  private def executeKnn[V](query: Query[Doc, Model, V],
+                            effective: Option[Filter[Doc]],
+                            bv: Sort.ByVectorDistance[Doc]): Task[SearchResults[Doc, Model, V]] = Task {
+    if (store.vectorField.isEmpty) throw new UnsupportedOperationException(s"Vector search requires a vector field on '${store.name}'")
+    if (bv.direction == SortDirection.Descending) throw new UnsupportedOperationException(
+      "Qdrant vector search returns nearest-first only; a descending Sort.ByVectorDistance is not supported."
+    )
+    val (qFilter, fullyPushed) = translateFilter(effective)
+    val want = query.offset + query.limit.orElse(query.pageSize).getOrElse(100)
+    // When the filter can't be fully pushed, over-fetch so the in-memory filter still yields enough.
+    val fetch = if (fullyPushed) want else math.min(want * 10 + 50, 10_000)
+    val vector = bv.vector.map(d => java.lang.Float.valueOf(d.toFloat)).asJava
+    val sb = SearchPoints.newBuilder()
+      .setCollectionName(coll)
+      .addAllVector(vector)
+      .setLimit(fetch.toLong)
+      .setWithPayload(WithPayloadSelectorFactory.enable(true))
+    qFilter.foreach(sb.setFilter)
+    var docs = client.searchAsync(sb.build()).get().asScala.toList.map(p => fromPayload(p.getPayloadMap))
+    if (!fullyPushed) effective.foreach(f => docs = docs.filter(d => NestedQuerySupport.eval(f, store.model, d)))
+    finish(query, docs, ordered = true)
+  }
+
+  private def executeScroll[V](query: Query[Doc, Model, V],
+                               effective: Option[Filter[Doc]]): Task[SearchResults[Doc, Model, V]] = Task {
+    val (qFilter, fullyPushed) = translateFilter(effective)
+    var candidates = scrollDocs(qFilter)
+    if (!fullyPushed) effective.foreach(f => candidates = candidates.filter(d => NestedQuerySupport.eval(f, store.model, d)))
+    candidates = applySort(candidates, query.sort)
+    finish(query, candidates, ordered = true)
+  }
+
+  /** Shared paging/conversion/faceting over an already-ordered candidate list. */
+  private def finish[V](query: Query[Doc, Model, V], candidates: List[Doc], ordered: Boolean): SearchResults[Doc, Model, V] = {
+    val total = if (query.countTotal) Some(candidates.size) else None
+    val pageLimit = math.min(query.limit.getOrElse(Int.MaxValue), query.pageSize.getOrElse(Int.MaxValue))
+    val dropped = if (query.offset > 0) candidates.drop(query.offset) else candidates
+    val page = if (pageLimit != Int.MaxValue) dropped.take(pageLimit) else dropped
+    val withScore = page.map(d => convertDoc(d, query.conversion) -> 0.0)
+    val facetResults: Map[Field.FacetField[Doc], FacetResult] =
+      if (query.facets.nonEmpty) FacetComputation.fromDocs(candidates, query.facets, store.model)
+      else Map.empty[Field.FacetField[Doc], FacetResult]
+    SearchResults(store.model, query.offset, query.limit, total, rapid.Stream.emits(withScore), facetResults, this)
+  }
+
+  private def applySort(docs: List[Doc], sorts: List[Sort]): List[Doc] =
+    if (sorts.isEmpty) docs
+    else {
+      val state = new IndexingState
+      sorts.foldRight(docs) { (s, acc) =>
+        s match {
+          case Sort.IndexOrder => acc.sortBy(_._id.value)
+          case bf: Sort.ByField[Doc, _] @unchecked =>
+            val field = bf.field.asInstanceOf[Field[Doc, Any]]
+            val sorted = acc.sortBy(d => field.getJson(d, state))(jsonOrdering)
+            if (bf.direction == SortDirection.Descending) sorted.reverse else sorted
+          case _: Sort.ByVectorDistance[_] =>
+            throw new UnsupportedOperationException("Vector sort must be the primary sort (handled natively); cannot combine with other sorts here.")
+          case _: Sort.ByDistance[_, _] =>
+            throw new UnsupportedOperationException(
+              "Spatial Sort.ByDistance is not supported by the Qdrant backend; use a backend with native spatial support."
+            )
+          case _ => acc
+        }
+      }
+    }
+
+  private val jsonOrdering: Ordering[Json] = Ordering.fromLessThan { (a, b) =>
+    (a, b) match {
+      case (NumInt(x, _), NumInt(y, _)) => x < y
+      case (NumDec(x, _), NumDec(y, _)) => x < y
+      case (NumInt(x, _), NumDec(y, _)) => BigDecimal(x) < y
+      case (NumDec(x, _), NumInt(y, _)) => x < BigDecimal(y)
+      case (Str(x, _), Str(y, _)) => x < y
+      case (Null, _) => true
+      case (_, Null) => false
+      case _ => a.toString < b.toString
+    }
+  }
+
+  private def convertDoc[V](doc: Doc, conversion: Conversion[Doc, V]): V = conversion match {
+    case Conversion.Doc() => doc.asInstanceOf[V]
+    case Conversion.Value(field) => field.get(doc, field, new IndexingState).asInstanceOf[V]
+    case Conversion.Converted(c) => c(doc)
+    case Conversion.Materialized(fields) =>
+      val state = new IndexingState
+      val json = obj(fields.map(f => f.name -> f.getJson(doc, state))*)
+      MaterializedIndex[Doc, Model](json, store.model).asInstanceOf[V]
+    case Conversion.DocAndIndexes() =>
+      val state = new IndexingState
+      val json = obj(store.fields.filter(_.indexed).map(f => f.name -> f.getJson(doc, state))*)
+      MaterializedAndDoc[Doc, Model](json, store.model, doc).asInstanceOf[V]
+    case Conversion.Json(fields) =>
+      val state = new IndexingState
+      obj(fields.map(f => f.name -> f.getJson(doc, state))*).asInstanceOf[V]
+    case Conversion.Distance(field, from, _, _) =>
+      val state = new IndexingState
+      val distance = field.get(doc, field, state).map(g => lightdb.spatial.Spatial.distance(from, g))
+      lightdb.spatial.DistanceAndDoc(doc, distance).asInstanceOf[V]
+    case _: Conversion.DocWithInnerHits[_, _] =>
+      lightdb.query.DocWithInnerHits[Doc, Model](doc = doc).asInstanceOf[V]
+  }
+
+  override def distinct[F](query: Query[Doc, Model, _],
+                          field: Field[Doc, F],
+                          pageSize: Int): rapid.Stream[F] = rapid.Stream.force {
+    val docQuery = Query[Doc, Model, Doc](this, Conversion.Doc(), filter = query.filter, sort = query.sort)
+    doSearch(docQuery).flatMap(_.stream.toList).map { docs =>
+      val state = new IndexingState
+      val seen = scala.collection.mutable.LinkedHashSet.empty[F]
+      docs.foreach(d => seen += field.get(d, field, state))
+      rapid.Stream.emits(seen.toList)
+    }
+  }
+
+  override def aggregate(query: AggregateQuery[Doc, Model]): rapid.Stream[MaterializedAggregate[Doc, Model]] =
+    lightdb.util.Aggregator(query, store.model)
+
+  override def aggregateCount(query: AggregateQuery[Doc, Model]): Task[Int] = aggregate(query).count
+}

--- a/qdrant/src/test/scala/spec/QdrantAvailability.scala
+++ b/qdrant/src/test/scala/spec/QdrantAvailability.scala
@@ -1,0 +1,14 @@
+package spec
+
+import org.scalatest.{AsyncTestSuite, FutureOutcome}
+
+/**
+ * Cancels (rather than fails) every test in a Qdrant-backed spec when no Qdrant is reachable
+ * (Docker/Testcontainers unavailable). Mirrors [[MongoDBAvailability]].
+ */
+trait QdrantAvailability extends AsyncTestSuite {
+  abstract override def withFixture(test: NoArgAsyncTest): FutureOutcome =
+    if QdrantTestSupport.config.isEmpty then
+      FutureOutcome.canceled("Qdrant unavailable — Docker/Testcontainers not available. Skipping.")
+    else super.withFixture(test)
+}

--- a/qdrant/src/test/scala/spec/QdrantTestContainer.scala
+++ b/qdrant/src/test/scala/spec/QdrantTestContainer.scala
@@ -1,0 +1,47 @@
+package spec
+
+import fabric.rw.stringRW
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import profig.Profig
+
+import java.time.Duration
+
+/**
+ * Lazily starts a Qdrant container via Testcontainers and tears it down at JVM exit. Exposes the gRPC
+ * port (6334) used by the Java client. Image overridable via the `lightdb.qdrant.testcontainers.image`
+ * Profig key.
+ */
+private[spec] object QdrantTestContainer {
+  private val GrpcPort = 6334
+  private val HttpPort = 6333
+
+  private class Container(image: DockerImageName) extends GenericContainer[Container](image)
+
+  private lazy val container: Container = {
+    val image = Profig("lightdb.qdrant.testcontainers.image").opt[String].getOrElse("qdrant/qdrant:latest")
+    val c = new Container(DockerImageName.parse(image))
+    c.withExposedPorts(GrpcPort, HttpPort)
+    c.waitingFor(Wait.forLogMessage(".*gRPC listening.*", 1).withStartupTimeout(Duration.ofMinutes(2)))
+    c
+  }
+
+  private lazy val started: Unit = {
+    container.start()
+    Runtime.getRuntime.addShutdownHook(new Thread(() => {
+      try container.stop()
+      catch { case _: Throwable => () }
+    }))
+  }
+
+  def host: String = {
+    started
+    container.getHost
+  }
+
+  def grpcPort: Int = {
+    started
+    container.getMappedPort(GrpcPort)
+  }
+}

--- a/qdrant/src/test/scala/spec/QdrantTestSupport.scala
+++ b/qdrant/src/test/scala/spec/QdrantTestSupport.scala
@@ -1,0 +1,20 @@
+package spec
+
+import lightdb.qdrant.{QdrantConfig, QdrantStoreManager}
+
+/**
+ * Resolves a Qdrant connection for tests via an ephemeral Testcontainers instance (auto-removed at
+ * JVM exit). Yields `None` when Docker is unavailable so specs cancel gracefully (see
+ * [[QdrantAvailability]]).
+ */
+object QdrantTestSupport {
+  lazy val config: Option[QdrantConfig] =
+    try Some(QdrantConfig(QdrantTestContainer.host, QdrantTestContainer.grpcPort))
+    catch {
+      case t: Throwable =>
+        scribe.warn(s"Qdrant unavailable: Testcontainers failed to start (${t.getMessage})")
+        None
+    }
+
+  def storeManager: QdrantStoreManager = QdrantStoreManager(config.get)
+}

--- a/qdrant/src/test/scala/spec/QdrantVectorSpec.scala
+++ b/qdrant/src/test/scala/spec/QdrantVectorSpec.scala
@@ -1,0 +1,94 @@
+package spec
+
+import fabric.rw.*
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel, JsonConversion}
+import lightdb.field.Field
+import lightdb.id.Id
+import lightdb.qdrant.{QdrantStore, QdrantStoreManager}
+import lightdb.upgrade.DatabaseUpgrade
+import lightdb.vector.VectorMetric
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import rapid.AsyncTaskSpec
+
+import java.nio.file.Path
+
+/** Verifies native Qdrant KNN (vector point + payload), plus the KV contract and hybrid filtering. */
+@EmbeddedTest
+class QdrantVectorSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with QdrantAvailability {
+  private val apple = Id[VDoc]("apple")
+  private val almostApple = Id[VDoc]("almostApple")
+  private val banana = Id[VDoc]("banana")
+  private val car = Id[VDoc]("car")
+
+  private val query = List(1.0, 0.0, 0.0)
+
+  "Qdrant" should {
+    "initialize" in {
+      DB.init.succeed
+    }
+    "insert documents with embeddings" in {
+      DB.docs.transaction(_.insert(List(
+        VDoc("apple", "fruit", List(1.0, 0.0, 0.0), apple),
+        VDoc("almost apple", "fruit", List(0.9, 0.1, 0.0), almostApple),
+        VDoc("banana", "fruit", List(0.0, 1.0, 0.0), banana),
+        VDoc("car", "vehicle", List(0.0, 0.0, 1.0), car)
+      ))).map(_ => succeed)
+    }
+    "count the stored documents" in {
+      DB.docs.transaction(_.count).map(_ should be(4))
+    }
+    "round-trip a document through the point payload" in {
+      DB.docs.transaction { tx =>
+        tx(apple).map { doc =>
+          doc.text should be("apple")
+          doc.embedding should be(List(1.0, 0.0, 0.0))
+        }
+      }
+    }
+    "return the nearest neighbors in order (cosine)" in {
+      DB.docs.transaction { tx =>
+        tx.query.sort(VDoc.embedding.knn(query)).limit(2).toList.map { docs =>
+          docs.map(_._id) should be(List(apple, almostApple))
+        }
+      }
+    }
+    "support hybrid search (filter + KNN)" in {
+      DB.docs.transaction { tx =>
+        tx.query.filter(_.category === "vehicle").sort(VDoc.embedding.knn(query)).limit(5).toList.map { docs =>
+          docs.map(_._id) should be(List(car))
+        }
+      }
+    }
+    "support a non-KNN filter query (scroll path)" in {
+      DB.docs.transaction { tx =>
+        tx.query.filter(_.category === "fruit").toList.map { docs =>
+          docs.map(_._id).toSet should be(Set(apple, almostApple, banana))
+        }
+      }
+    }
+    "dispose" in {
+      DB.truncate().flatMap(_ => DB.dispose).succeed
+    }
+  }
+
+  case class VDoc(text: String, category: String, embedding: List[Double], _id: Id[VDoc] = Id()) extends Document[VDoc]
+
+  object VDoc extends DocumentModel[VDoc] with JsonConversion[VDoc] {
+    override implicit val rw: RW[VDoc] = RW.gen
+
+    val text: I[String] = field.index("text", _.text)
+    val category: I[String] = field.index("category", _.category)
+    val embedding: Field.VectorIndex[VDoc] = field.vector("embedding", _.embedding, dimension = 3, metric = VectorMetric.Cosine)
+  }
+
+  object DB extends LightDB {
+    override type SM = QdrantStoreManager
+    override val storeManager: QdrantStoreManager = QdrantTestSupport.storeManager
+    override def name: String = "QdrantVectorSpec"
+    override lazy val directory: Option[Path] = None
+    val docs: QdrantStore[VDoc, VDoc.type] = store(VDoc)()
+    override def upgrades: List[DatabaseUpgrade] = Nil
+  }
+}

--- a/sql/src/main/scala/lightdb/sql/SQLStore.scala
+++ b/sql/src/main/scala/lightdb/sql/SQLStore.scala
@@ -74,12 +74,19 @@ abstract class SQLStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name:
         if field == model._id then {
           s"${SqlIdent.quote("_id")} VARCHAR NOT NULL PRIMARY KEY"
         } else {
-          val t = def2Type(field.name, field.rw.definition)
+          val t = columnType(field)
           s"${SqlIdent.quote(field.name)} $t"
         }
     }.mkString(", ")
     executeUpdate(s"CREATE TABLE IF NOT EXISTS $fqn($entries)", tx)
   }
+
+  /**
+   * SQL column type for a field. Defaults to [[def2Type]] over the field's serialized definition;
+   * dialects override to emit type that depends on field metadata rather than just its `DefType`
+   * (e.g. PostgreSQL emits `vector(N)` for a [[lightdb.field.Field.VectorIndex]]).
+   */
+  protected def columnType(field: Field[Doc, _]): String = def2Type(field.name, field.rw.definition)
 
   protected def def2Type(name: String, d: Definition): String = d.defType match {
     case DefType.Str | DefType.Json | DefType.Obj(_) | DefType.Arr(_) | DefType.Poly(_, _) =>
@@ -93,7 +100,7 @@ abstract class SQLStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name:
 
   protected def addColumn(field: Field[Doc, _], tx: TX): Unit = {
     scribe.info(s"Adding column $fqn.${field.name}")
-    executeUpdate(s"ALTER TABLE $fqn ADD COLUMN ${SqlIdent.quote(field.name)} ${def2Type(field.name, field.rw.definition)}", tx)
+    executeUpdate(s"ALTER TABLE $fqn ADD COLUMN ${SqlIdent.quote(field.name)} ${columnType(field)}", tx)
   }
 
   /** Whether this backend supports `ALTER COLUMN ... TYPE`. SQLite (dynamically
@@ -148,7 +155,7 @@ abstract class SQLStore[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name:
   }
 
   protected def migrateColumnType(field: Field[Doc, _], tx: TX): Unit = {
-    val newType = def2Type(field.name, field.rw.definition)
+    val newType = columnType(field)
     scribe.warn(s"Migrating column type $fqn.${field.name} -> $newType")
     executeUpdate(alterColumnTypeSQL(field.name, newType), tx)
   }

--- a/sql/src/main/scala/lightdb/sql/SQLStoreTransaction.scala
+++ b/sql/src/main/scala/lightdb/sql/SQLStoreTransaction.scala
@@ -516,6 +516,14 @@ trait SQLStoreTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
         store.fields
     }
 
+    // Vector KNN: inject the per-row distance expression (bound to the query vector) as an extra
+    // SELECT column so ORDER BY can reference it by alias (see sortByVectorDistance).
+    query.sort.foreach {
+      case s: Sort.ByVectorDistance[_] =>
+        extraFields = extraFields ::: extraFieldsForVectorDistance(s.asInstanceOf[Sort.ByVectorDistance[Doc]])
+      case _ => ()
+    }
+
     val bestMatchDirectionOpt: Option[SortDirection] = query.sort.collectFirst {
       case Sort.BestMatch(direction) => direction
     }
@@ -544,6 +552,7 @@ trait SQLStoreTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
           val dir = if direction == SortDirection.Descending then "DESC" else "ASC"
           List(SQLPart.Fragment(s"${SqlIdent.quote(index.name)} $dir"))
         case Sort.ByDistance(field, _, direction) => List(sortByDistance(field, direction))
+        case Sort.ByVectorDistance(field, _, _, direction) => List(sortByVectorDistance(field, direction))
         case _ => Nil
       },
       limit = query.limit.orElse(query.pageSize),
@@ -1147,7 +1156,7 @@ trait SQLStoreTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
     case v => throw new RuntimeException(s"Unsupported type: $v (${v.getClass.getName})")
   }
 
-  private def obj2Value(obj: Any): Any = obj match {
+  protected def obj2Value(obj: Any): Any = obj match {
     case null => null
     case s: String => s
     case b: java.lang.Boolean => b.booleanValue()
@@ -1447,6 +1456,24 @@ trait SQLStoreTransaction[Doc <: Document[Doc], Model <: DocumentModel[Doc]]
 
   protected def extraFieldsForDistance(conversion: Conversion.Distance[Doc, _]): List[SQLPart] =
     throw new UnsupportedOperationException("Distance conversions not supported")
+
+  /**
+   * ORDER BY part for a vector KNN sort. Orders by the distance pseudo-column emitted by
+   * [[extraFieldsForVectorDistance]] (referenced by its alias), so dialects only need to override the
+   * latter. Ascending = nearest first.
+   */
+  protected def sortByVectorDistance(field: Field[_, List[Double]], direction: SortDirection): SQLPart = {
+    val dir = if direction == SortDirection.Descending then "DESC" else "ASC"
+    SQLPart.Fragment(s"${SqlIdent.quote(s"${field.name}VectorDistance")} $dir")
+  }
+
+  /**
+   * Extra SELECT field(s) computing the per-row vector distance for a KNN sort, bound to the query
+   * vector and aliased `${field.name}VectorDistance`. Only meaningful on backends with native vector
+   * support (e.g. PostgreSQL + pgvector); the default rejects vector sorts.
+   */
+  protected def extraFieldsForVectorDistance(sort: Sort.ByVectorDistance[Doc]): List[SQLPart] =
+    throw new UnsupportedOperationException("Vector distance sort not supported in this SQL backend")
 }
 
 object SQLStoreTransaction {

--- a/tantivy/src/main/scala/lightdb/tantivy/TantivySort.scala
+++ b/tantivy/src/main/scala/lightdb/tantivy/TantivySort.scala
@@ -17,6 +17,11 @@ object TantivySort {
         "Tantivy backend does not support Sort.ByDistance — no native geo support. " +
           "Use a backend like lucene; this is deliberately not emulated."
       )
+    case _: Sort.ByVectorDistance[?] =>
+      throw new UnsupportedOperationException(
+        "Tantivy backend does not support Sort.ByVectorDistance — no native vector support. " +
+          "Use a backend with native vector support such as PostgreSQL with pgvector; this is deliberately not emulated."
+      )
   }
 
   private def direction(d: SortDirection): pb.SortDirection = d match {

--- a/traversal/src/main/scala/lightdb/traversal/store/TraversalQueryEngine.scala
+++ b/traversal/src/main/scala/lightdb/traversal/store/TraversalQueryEngine.scala
@@ -32,6 +32,12 @@ import scala.util.control.NonFatal
  * Over time, this engine is intended to be replaced with index-backed planning + execution.
  */
 object TraversalQueryEngine {
+  // Vector KNN is a declared, native capability — this engine has no ANN index, and a brute-force
+  // scan would mislead users into expecting performance it can't deliver. Reject it clearly instead.
+  private[traversal] val VectorSortUnsupported: String =
+    "Vector search (Sort.ByVectorDistance) is not supported by this store; use a backend with native " +
+      "vector support such as PostgreSQL with pgvector."
+
   // Shared config for bounded seed materialization.
   private lazy val MaxSeedSize: Int = {
     Profig("lightdb.traversal.persistedIndex.maxSeedSize").opt[Int].getOrElse(100_000)
@@ -681,6 +687,8 @@ object TraversalQueryEngine {
       case Sort.ByField(_, direction) => direction
       case Sort.IndexOrder => SortDirection.Ascending
       case Sort.ByDistance(_, _, direction) => direction
+      case _: Sort.ByVectorDistance[_] =>
+        throw new UnsupportedOperationException(TraversalQueryEngine.VectorSortUnsupported)
     }
 
     def distanceMin(doc: Doc, field: Field[Doc, List[Geo]], from: Point): Double = {
@@ -705,6 +713,8 @@ object TraversalQueryEngine {
           f.get(doc, f, state)
         case Sort.ByDistance(field, from, _) =>
           distanceMin(doc, field.asInstanceOf[Field[Doc, List[Geo]]], from)
+        case _: Sort.ByVectorDistance[_] =>
+          throw new UnsupportedOperationException(TraversalQueryEngine.VectorSortUnsupported)
       }
 
     def compareHits(a: Hit, b: Hit): Int = {
@@ -3261,6 +3271,8 @@ object TraversalQueryEngine {
         case Sort.ByField(_, direction) => direction
         case Sort.IndexOrder => SortDirection.Ascending
         case Sort.ByDistance(_, _, direction) => direction
+        case _: Sort.ByVectorDistance[_] =>
+          throw new UnsupportedOperationException(TraversalQueryEngine.VectorSortUnsupported)
       }
 
       def keyFor(sort: Sort, doc: Doc, score: Double): Any = sort match {
@@ -3275,6 +3287,8 @@ object TraversalQueryEngine {
             .flatMap(_.map(_.valueInMeters).minOption)
             .getOrElse(Double.PositiveInfinity)
           min
+        case _: Sort.ByVectorDistance[_] =>
+          throw new UnsupportedOperationException(TraversalQueryEngine.VectorSortUnsupported)
       }
 
       docs.sortWith { case ((d1, s1), (d2, s2)) =>


### PR DESCRIPTION
Adds first-class vector / embedding nearest-neighbor (KNN) search to LightDB.

## Public API
- Declare a vector field: `field.vector("embedding", _.embedding, dimension = 1536, metric = VectorMetric.Cosine)` (value type `List[Double]`).
- Search: `query.sort(Model.embedding.knn(queryVector)).limit(k)` returns the top-k nearest; composes with regular filters for hybrid search.
- `VectorMetric`: `Cosine` / `Euclidean` / `DotProduct`, mapped to each backend's native operator/index.

## Native-only by design
Vector search is a declared, native capability. Backends without a real ANN index do **not** emulate it — a brute-force scan would mislead users into expecting performance the store can't deliver (a KV store would re-parse every vector from JSON, O(n), per query). Every non-native backend (Lucene*, OpenSearch, MongoDB, ArangoDB, Tantivy, the SQL family without pgvector, and the traversal/KV engine) rejects a vector sort with a clear `UnsupportedOperationException` rather than silently mis-sorting. (MongoDB and ArangoDB previously had a catch-all that would have silently returned wrong order — now fixed.)

## Backends
1. **PostgreSQL + pgvector** — `vector(N)` columns, HNSW index with metric-matched operator class, `ORDER BY emb <op> ?` (`<=>`/`<->`/`<#>`), `?::vector` binding, `PGobject` read-back. `CREATE EXTENSION vector` is gated on models that declare a vector field. `SQLStore` gains a field-aware `columnType` hook (default unchanged for all other SQL dialects).
2. **Lucene HNSW** (embedded) — `KnnFloatVectorField` (metric → `VectorSimilarityFunction`) + stored JSON for round-trip; a vector sort becomes a `KnnFloatVectorQuery` (top-k, filter applied as a pre-filter), ordered by similarity. Nearest-first only.
3. **Qdrant** (new `qdrant` module, `io.qdrant:client` gRPC) — vector-first store. Each document maps to a point (vector field → point vector; payload = full doc JSON for round-trip + indexed scalars for filter push-down; point id = deterministic UUID from `_id`). Native KNN via `searchAsync` with equality/AND filter push-down; non-KNN queries via scroll + in-memory filter/sort. Intentionally **not** a `PrefixScanningStore` (no ordered key scan), so it is excluded from the traversal/graph DSL — Qdrant's strength is vectors, not general storage. Models without a vector field still work as a plain key/value collection.

## Tests
New specs use the existing Testcontainers self-provisioning + Availability-skip pattern (cancel gracefully when Docker is unavailable):
- pgvector KNN (`pgvector/pgvector:pg17`)
- Lucene KNN (in-memory index)
- Qdrant KNN + KV + hybrid + scroll (`qdrant/qdrant`)

Full regression run green: core, traversal, h2, sqlite, lucene, postgresql, duckdb, mariadb; `all/compile` clean.

\* Lucene's rejection is a placeholder removed by the Lucene HNSW commit; on this branch Lucene is fully native.