### PR TITLE
reIndex rebuilds full collections by streaming read -> upsert

### DIFF
--- a/core/src/main/scala/lightdb/store/Collection.scala
+++ b/core/src/main/scala/lightdb/store/Collection.scala
@@ -2,9 +2,12 @@ package lightdb.store
 
 import lightdb.LightDB
 import lightdb.doc.{Document, DocumentModel}
+import lightdb.progress.ProgressManager
 import lightdb.transaction.CollectionTransaction
+import rapid.Task
 
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
 
 abstract class Collection[Doc <: Document[Doc], Model <: DocumentModel[Doc]](name: String,
                                                                              path: Option[Path],
@@ -12,4 +15,45 @@ abstract class Collection[Doc <: Document[Doc], Model <: DocumentModel[Doc]](nam
                                                                              lightDB: LightDB,
                                                                              storeManager: StoreManager) extends Store[Doc, Model](name, path, model, lightDB, storeManager) {
   override type TX <: CollectionTransaction[Doc, Model]
+
+  /**
+   * Rebuilds derived/indexed data for a full (`StoreMode.All`) collection by re-writing every stored
+   * document. A field's value is produced by its getter at write time, so a newly-added computed or
+   * indexed field (e.g. `field.index(d => s"${d.name}.${d.age}")`) is `NULL`/absent for rows written
+   * before it existed; re-writing each document recomputes those projections and refreshes the index.
+   * Call this once after adding such a field.
+   *
+   * Streams the documents straight from the read into the upsert (no materialization), so it scales to
+   * very large collections with bounded memory. This is a maintenance operation, not a hot path.
+   *
+   * Stores whose documents live elsewhere (`StoreMode.Indexes` / split storage) cannot rebuild from
+   * themselves and override this — see [[lightdb.store.split.SplitCollection]], which re-derives the
+   * index from the backing storage instead.
+   */
+  override def reIndex(progressManager: ProgressManager = ProgressManager.none): Task[Boolean] =
+    if !storeMode.isAll then {
+      super.reIndex(progressManager)
+    } else {
+      transaction { tx =>
+        tx.count.flatMap { total =>
+          val counter = new AtomicInteger(0)
+          val stream = tx.stream.evalTap { _ =>
+            Task {
+              val current = counter.incrementAndGet()
+              progressManager.percentage(
+                current = current,
+                total = total,
+                message = Some(s"Re-Indexing $name: $current of $total")
+              )
+            }
+          }
+          tx.upsert(stream)
+        }.map(_ => true)
+      }
+    }
+
+  /** Re-writes a single document so its derived/indexed projections are recomputed. */
+  override def reIndexDoc(doc: Doc): Task[Boolean] = transaction { tx =>
+    tx.upsert(doc).map(_ => true)
+  }
 }

--- a/h2/src/test/scala/spec/H2ReIndexSpec.scala
+++ b/h2/src/test/scala/spec/H2ReIndexSpec.scala
@@ -1,0 +1,74 @@
+package spec
+
+import fabric.rw.*
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel, JsonConversion}
+import lightdb.h2.H2Store
+import lightdb.id.Id
+import lightdb.sql.SQLCollectionManager
+import lightdb.upgrade.DatabaseUpgrade
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import rapid.AsyncTaskSpec
+
+/**
+ * Verifies that `reIndex` on a full (StoreMode.All) collection re-derives computed/indexed field
+ * values for existing rows by re-writing every document. The `tag` field's value depends on a mutable
+ * suffix, simulating a newly-added or changed derivation: rows written before the change keep their
+ * old derived value until `reIndex` rebuilds them.
+ */
+@EmbeddedTest
+class H2ReIndexSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers {
+  // Large enough to exceed the streaming fetch size and force write-batch flushes while the read
+  // cursor is still open on the same transaction/connection (the case reIndex must handle).
+  private val count = 2500
+
+  "reIndex" should {
+    "re-derive a computed indexed field for existing rows (streaming, same transaction)" in {
+      val db = new TestDB
+      ReIndexState.suffix = "v1"
+      val docs = Person("bob") :: (1 until count).map(i => Person(s"p$i")).toList
+      for {
+        _ <- db.init
+        _ <- db.people.transaction(_.insert(docs))
+        v1Before <- db.people.transaction(_.query.filter(_.tag === "bob-v1").toList.map(_.map(_.name)))
+        _ = { ReIndexState.suffix = "v2" } // the derivation changes (e.g. a new/changed computed field)
+        staleV2 <- db.people.transaction(_.query.filter(_.tag === "bob-v2").toList.map(_.map(_.name)))
+        reIndexed <- db.people.reIndex()
+        countAfter <- db.people.transaction(_.count)
+        afterV2 <- db.people.transaction(_.query.filter(_.tag === "bob-v2").toList.map(_.map(_.name)))
+        afterV1 <- db.people.transaction(_.query.filter(_.tag === "bob-v1").toList.map(_.map(_.name)))
+        _ <- db.dispose
+      } yield {
+        v1Before should be(List("bob"))  // derived at insert with the v1 suffix
+        staleV2 should be(Nil)           // stale until reIndex
+        reIndexed should be(true)
+        countAfter should be(count)      // streaming re-write preserves every document
+        afterV2 should be(List("bob"))   // reIndex re-derived with the v2 suffix
+        afterV1 should be(Nil)           // the old derived value is gone
+      }
+    }
+  }
+
+  object ReIndexState {
+    @volatile var suffix: String = "v1"
+  }
+
+  case class Person(name: String, _id: Id[Person] = Id()) extends Document[Person]
+
+  object Person extends DocumentModel[Person] with JsonConversion[Person] {
+    override implicit val rw: RW[Person] = RW.gen
+
+    val name: I[String] = field.index("name", _.name)
+    val tag: I[String] = field.index("tag", d => s"${d.name}-${ReIndexState.suffix}")
+  }
+
+  final class TestDB extends LightDB {
+    override type SM = SQLCollectionManager
+    override val storeManager: SQLCollectionManager = H2Store
+    override def name: String = "H2ReIndexSpec"
+    override def directory: Option[java.nio.file.Path] = None
+    override def upgrades: List[DatabaseUpgrade] = Nil
+    val people: S[Person, Person.type] = store(Person)()
+  }
+}

--- a/postgresql/src/test/scala/spec/PostgreSQLReIndexSpec.scala
+++ b/postgresql/src/test/scala/spec/PostgreSQLReIndexSpec.scala
@@ -1,0 +1,76 @@
+package spec
+
+import fabric.rw.*
+import lightdb.LightDB
+import lightdb.doc.{Document, DocumentModel, JsonConversion}
+import lightdb.id.Id
+import lightdb.postgresql.{PostgreSQLStore, PostgreSQLStoreManager}
+import lightdb.upgrade.DatabaseUpgrade
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import rapid.AsyncTaskSpec
+
+import java.nio.file.Path
+
+/**
+ * Verifies `reIndex` streams read -> upsert with bounded memory on PostgreSQL (the at-scale target):
+ * a computed indexed field whose derivation changes is stale until `reIndex`, then repopulated for all
+ * pre-existing rows. Uses enough rows to exceed the streaming fetch size and force write flushes while
+ * the read cursor is open.
+ */
+@EmbeddedTest
+class PostgreSQLReIndexSpec extends AsyncWordSpec with AsyncTaskSpec with Matchers with PostgreSQLAvailability {
+  // Exceeds both the read fetch size (1000) and several write-flush overflow cycles
+  // (MaxInsertBatch 5000), so the run streams server-side with bounded memory rather than buffering.
+  private val count = 12000
+
+  "PostgreSQL reIndex" should {
+    "re-derive a computed indexed field for all existing rows" in {
+      ReIndexState.suffix = "v1"
+      val docs = Person("bob", Id[Person]("bob")) :: (1 until count).map(i => Person(s"p$i", Id[Person](s"p$i"))).toList
+      for {
+        _ <- DB.init
+        _ <- DB.people.transaction(_.truncate)
+        _ <- DB.people.transaction(_.insert(docs))
+        v1Before <- DB.people.transaction(_.query.filter(_.tag === "bob-v1").toList.map(_.map(_.name)))
+        _ = { ReIndexState.suffix = "v2" }
+        staleV2 <- DB.people.transaction(_.query.filter(_.tag === "bob-v2").toList.map(_.map(_.name)))
+        reIndexed <- DB.people.reIndex()
+        countAfter <- DB.people.transaction(_.count)
+        afterV2 <- DB.people.transaction(_.query.filter(_.tag === "bob-v2").toList.map(_.map(_.name)))
+        afterV1 <- DB.people.transaction(_.query.filter(_.tag === "bob-v1").toList.map(_.map(_.name)))
+        _ <- DB.truncate()
+        _ <- DB.dispose
+      } yield {
+        v1Before should be(List("bob"))
+        staleV2 should be(Nil)
+        reIndexed should be(true)
+        countAfter should be(count)
+        afterV2 should be(List("bob"))
+        afterV1 should be(Nil)
+      }
+    }
+  }
+
+  object ReIndexState {
+    @volatile var suffix: String = "v1"
+  }
+
+  case class Person(name: String, _id: Id[Person] = Id()) extends Document[Person]
+
+  object Person extends DocumentModel[Person] with JsonConversion[Person] {
+    override implicit val rw: RW[Person] = RW.gen
+
+    val name: I[String] = field.index("name", _.name)
+    val tag: I[String] = field.index("tag", d => s"${d.name}-${ReIndexState.suffix}")
+  }
+
+  object DB extends LightDB {
+    override type SM = PostgreSQLStoreManager
+    override val storeManager: PostgreSQLStoreManager = PostgreSQLTestSupport.storeManager
+    override def name: String = "PostgreSQLReIndexSpec"
+    override lazy val directory: Option[Path] = None
+    val people: PostgreSQLStore[Person, Person.type] = store(Person)()
+    override def upgrades: List[DatabaseUpgrade] = Nil
+  }
+}


### PR DESCRIPTION
## Problem
`Store.reIndex` was a no-op (returned `false`) for everything except split collections. So when you add a **computed/derived** indexed field — e.g. `field.index(d => s"${d.name}.${d.age}")` — existing rows have no value for it (the value is produced by the field getter at write time, and `ALTER TABLE ADD COLUMN` leaves old rows `NULL`), with no built-in way to backfill.

## Change
`Collection` now provides a default `reIndex` for `StoreMode.All` stores that **streams every stored document straight from the read into the upsert** — one transaction, no materialization. Each field getter re-runs, so the derived/indexed projections are recomputed and the index refreshed. A one-time `db.store.reIndex()` rebuilds it; `reIndexDoc(doc)` re-writes a single document.

It mirrors the split-collection pattern (re-derive from the source), adapted to a unified store: the store *is* the source, so it re-writes the documents themselves. `StoreMode.Indexes` / split stores keep their existing override (`SplitCollection` re-derives from backing storage) — guarded by `storeMode.isAll`.

## Scales to very large collections
Memory stays bounded regardless of size — no full materialization:
- **Read** is a server-side cursor: `SQLState` sets `setFetchSize(1000)` and `SQLConfig.autoCommit` defaults to `false` (the Postgres streaming recipe).
- **Writes** flush in chunks via the queued write handler (`MaxInsertBatch` 5000, flush-on-overflow).

So the pipeline holds only a few thousand docs at a time whether the collection has 10 rows or hundreds of millions.

## Tests
- `H2ReIndexSpec` (2500 rows) and `PostgreSQLReIndexSpec` (12000 rows — exceeds the fetch size and several write-flush overflow cycles, exercising server-side streaming + interleaved writes on one connection): a computed indexed field whose derivation changes is stale until `reIndex`, then repopulated for **every** pre-existing row, with the document count preserved.

Local regression green: core, h2, sqlite, rocksdb (split + traversal), lucene.